### PR TITLE
docs(readme): remove depd link because file is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Alternatively, instead of using env generator, you can cherry-pick and combine r
 ### polyfills
 
 - [consola](./src/runtime/npm/consola.ts)
-- [depd](./src/runtime/npm/depd.ts)
 - [mime-db](./src/runtime/npm/mime-db.ts)
 - [mime](./src/runtime/npm/mime.ts)
 - [debug](./src/runtime/npm/debug.ts)


### PR DESCRIPTION
This PR removes the `depd` link in the README as it 404s.