### PR TITLE
fix: use subpath import for `node/http`

### DIFF
--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -6,7 +6,7 @@ export default {
     ...mapArrToVal('unenv/runtime/mock/proxy', NodeBuiltinModules),
 
     // Custom
-    http: 'unenv/runtime/node/http',
+    http: 'unenv/runtime/node/http/index',
     process: 'unenv/runtime/polyfill/process',
     _process: 'process/browser.js',
 


### PR DESCRIPTION
closes #5 