### PR TITLE
fix: remove `node-fetch` alias from node preset

### DIFF
--- a/src/presets/node.ts
+++ b/src/presets/node.ts
@@ -2,10 +2,6 @@ import { NodeBuiltinModules } from '../utils'
 import type { Preset } from '../types'
 
 export default {
-  alias: {
-    'node-fetch': 'node-fetch/lib/index.js'
-  },
-
   inject: {
     fetch: 'node-fetch',
     Request: ['node-fetch', 'Request'],


### PR DESCRIPTION
Context: https://github.com/unjs/unenv/commit/d98283339b2ab8c78c4cda6932e25e49b8d05bde
Also https://github.com/nuxt/framework/blob/0c14b0a48ba82fbb49dfef3acf3c380a86b4fe49/packages/nitro/src/rollup/config.ts#L61 

**Reasons**:
* this doesn't support node-fetch v3 which has a different package location
* it can cause a circular dependency where `node-fetch` (if resolved twice) is imported from `node-fetch/lib/index.js/lib/index.js`, which fails
* it forces to the cjs version of the library

However, I'm not clear why this alias was included in the first place - guidance welcome.