### PR TITLE
fix: allow mocking subpaths of proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
       "import": "./dist/index.mjs"
     },
     "./runtime/mock/proxy-cjs": "./runtime/mock/proxy.cjs",
+    "./runtime/mock/proxy-cjs/*": "./runtime/mock/proxy.cjs",
     "./runtime/*": {
       "require": "./runtime/*.cjs",
       "import": "./runtime/*.mjs"


### PR DESCRIPTION
https://github.com/nuxt/framework/issues/2724, https://github.com/nuxt/framework/issues/5482

When something that has been aliased to `proxy-cjs` is accessed with a subpath, it falls back to the next valid subpath, which will never succeed: import (`unenv/runtime/*` => `unenv/runtime/mock/proxy-cjs/.cjs`).