### PR TITLE
fix: export named `fetch` from `node-fetch` polyfill

### DIFF
--- a/src/runtime/npm/node-fetch.ts
+++ b/src/runtime/npm/node-fetch.ts
@@ -1,7 +1,7 @@
 // https://github.com/node-fetch/node-fetch
 
 // Native browser APIs
-const fetch = (...args: Parameters<typeof globalThis["fetch"]>) => globalThis.fetch(...args);
+export const fetch = (...args: Parameters<typeof globalThis["fetch"]>) => globalThis.fetch(...args);
 
 export const Headers = globalThis.Headers;
 export const Request = globalThis.Request;


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a named fetch export for compatibility with `node-fetch-native`: https://github.com/unjs/node-fetch-native/blob/main/src/index.ts#L12.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
