### PR TITLE
fix(events): export once function

### DIFF
--- a/src/runtime/node/events/index.ts
+++ b/src/runtime/node/events/index.ts
@@ -2,10 +2,12 @@
 import type events from "node:events";
 
 // @ts-ignore
-import { EventEmitter as _EventEmitter } from "./_events";
+import { EventEmitter as _EventEmitter, once as _once } from "./_events";
 
 export const EventEmitter = _EventEmitter as any as typeof events.EventEmitter;
+export const once = _once as any as typeof events.once;
 
-export default <typeof events>{
+export default <typeof events> {
   EventEmitter,
-};
+  once,
+}


### PR DESCRIPTION
This PR exports the `once` function in the `event`  node runtime polyfill

patched the library (using pnpm) in my current project, was able to complete the build successfully.
![image](https://user-images.githubusercontent.com/18086566/214308040-c87066fd-2ee5-4539-8606-ac11f3405772.png)

should fix #54 