### PR TITLE
fix: add `extend` method to debug mock

### DIFF
--- a/src/runtime/npm/debug.ts
+++ b/src/runtime/npm/debug.ts
@@ -9,6 +9,7 @@ Object.assign(debug, {
   disable: noop,
   enable: noop,
   enabled: noop,
+  extend: debug,
   humanize: noop,
   destroy: noop,
   init: noop,


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/15608

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds the `extend` method to our debug mock.

https://github.com/debug-js/debug/blob/d1616622e4d404863c5a98443f755b4006e971dc/src/common.js#L149-L153

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
