### PR TITLE
feat(node): add `node:crypto` polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Module | Status | Source
 [node:cluster](https://nodejs.org/api/cluster.html) | Mocked | -
 [node:console](https://nodejs.org/api/console.html) | Mocked | -
 [node:constants](https://nodejs.org/api/constants.html) | Mocked | -
-[node:crypto](https://nodejs.org/api/crypto.html) | Mocked | -
+[node:crypto](https://nodejs.org/api/crypto.html) | Polyfilled | [unenv/node/crypto](./src/runtime/node/crypto)
 [node:dgram](https://nodejs.org/api/dgram.html) | Mocked | -
 [node:diagnostics_channel](https://nodejs.org/api/diagnostics_channel.html) | Mocked | -
 [node:dns](https://nodejs.org/api/dns.html) | Mocked | -

--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -11,6 +11,7 @@ const nodeless: Preset & { alias: Map<string, string> } = {
     ...Object.fromEntries(
       [
         "buffer",
+        "crypto",
         "events",
         "fs",
         "fs/promises",

--- a/src/runtime/node/crypto/index.ts
+++ b/src/runtime/node/crypto/index.ts
@@ -1,0 +1,22 @@
+// https://nodejs.org/api/crypto.html
+// https://github.com/unjs/uncrypto
+
+import type crypto from "node:crypto";
+
+const webCrypto = globalThis.crypto;
+
+export const subtle: Crypto["subtle"] = webCrypto.subtle;
+
+export const randomUUID: Crypto["randomUUID"] = () => {
+  return webCrypto.randomUUID();
+};
+
+export const getRandomValues: Crypto["getRandomValues"] = (array: any) => {
+  return webCrypto.getRandomValues(array);
+};
+
+export default <typeof crypto>{
+  randomUUID,
+  getRandomValues,
+  subtle,
+};

--- a/src/runtime/node/crypto/index.ts
+++ b/src/runtime/node/crypto/index.ts
@@ -10,12 +10,13 @@ export const randomUUID: typeof nodeCrypto.randomUUID = () => {
   return webCrypto.randomUUID();
 };
 
-export const getRandomValues: typeof nodeCrypto.getRandomValues = (array: any) => {
+export const getRandomValues: typeof nodeCrypto.getRandomValues = (
+  array: any
+) => {
   return webCrypto.getRandomValues(array);
 };
 
-
-export default <typeof nodeCrypto> {
+export default <typeof nodeCrypto>{
   randomUUID,
   getRandomValues,
   subtle,

--- a/src/runtime/node/crypto/index.ts
+++ b/src/runtime/node/crypto/index.ts
@@ -1,21 +1,21 @@
 // https://nodejs.org/api/crypto.html
 // https://github.com/unjs/uncrypto
-
-import type crypto from "node:crypto";
+import type nodeCrypto from "node:crypto";
 
 const webCrypto = globalThis.crypto;
 
-export const subtle: Crypto["subtle"] = webCrypto.subtle;
+export const subtle: typeof nodeCrypto.subtle = webCrypto.subtle;
 
-export const randomUUID: Crypto["randomUUID"] = () => {
+export const randomUUID: typeof nodeCrypto.randomUUID = () => {
   return webCrypto.randomUUID();
 };
 
-export const getRandomValues: Crypto["getRandomValues"] = (array: any) => {
+export const getRandomValues: typeof nodeCrypto.getRandomValues = (array: any) => {
   return webCrypto.getRandomValues(array);
 };
 
-export default <typeof crypto>{
+
+export default <typeof nodeCrypto> {
   randomUUID,
   getRandomValues,
   subtle,


### PR DESCRIPTION
[unjs/uncrypto](https://github.com/unjs/uncrypto) has a dual export for node/web crypto but some libraries / export conditions won't pick it. It adds built-in crypto polywill via global natives to also avoid a mock with never-resolving promises.