### PR TITLE
feat(node/crypto): implement `randomBytes`

### DIFF
--- a/src/runtime/node/crypto/index.ts
+++ b/src/runtime/node/crypto/index.ts
@@ -1,6 +1,7 @@
 // https://nodejs.org/api/crypto.html
 // https://github.com/unjs/uncrypto
 import type nodeCrypto from "node:crypto";
+import { notImplemented } from "src/runtime/_internal/utils";
 
 const webcrypto = globalThis.crypto;
 
@@ -16,10 +17,13 @@ export const getRandomValues: typeof nodeCrypto.getRandomValues = (
   return webcrypto.getRandomValues(array);
 };
 
+export const randomBytes = notImplemented("webcrypto.randomBytes");
+
 // TODO: Add missing exports (typecheck is not working!)
 export default <typeof nodeCrypto>{
   randomUUID,
   getRandomValues,
+  randomBytes,
   subtle,
   webcrypto,
 };

--- a/src/runtime/node/crypto/index.ts
+++ b/src/runtime/node/crypto/index.ts
@@ -1,15 +1,14 @@
 // https://nodejs.org/api/crypto.html
 // https://github.com/unjs/uncrypto
 import type nodeCrypto from "node:crypto";
-import { Buffer } from "../buffer";
-
-// limit of Crypto.getRandomValues()
-// https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
-const MAX_BYTES: number = 65_536;
 
 const webcrypto = globalThis.crypto;
 
 export const subtle: typeof nodeCrypto.subtle = webcrypto.subtle;
+
+// limit of Crypto.getRandomValues()
+// https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
+const MAX_BYTES: number = 65_536;
 
 export const randomUUID: typeof nodeCrypto.randomUUID = () => {
   return webcrypto.randomUUID();
@@ -21,25 +20,19 @@ export const getRandomValues: typeof nodeCrypto.getRandomValues = (
   return webcrypto.getRandomValues(array);
 };
 
-type randomBytesCallback = (err: null, buffer: Uint8Array) => void;
-export const randomBytes: typeof nodeCrypto.randomBytes = (
-  size: number,
-  cb: randomBytesCallback
-) => {
-  const bytes = Buffer.allocUnsafe(size);
+export const randomBytes /* :typeof nodeCrypto.randomBytes */ = (size: number, cb?: (err: Error | null, buf: Buffer) => void) => {
+  const bytes = Buffer.alloc(size, 0, undefined) as Buffer;
 
   for (let generated = 0; generated < size; generated += MAX_BYTES) {
     // buffer.slice automatically checks if the end is past the end of
     // the buffer so we don't have to here
-    getRandomValues(bytes.slice(generated, generated + MAX_BYTES));
+    getRandomValues(Uint8Array.prototype.slice.call(bytes, generated, generated + MAX_BYTES));
   }
 
   if (typeof cb === "function") {
-    return process.nextTick(function () {
-      cb(null, bytes);
-    });
+    cb(null, bytes)
+    return
   }
-
   return bytes;
 };
 

--- a/src/runtime/node/crypto/index.ts
+++ b/src/runtime/node/crypto/index.ts
@@ -1,7 +1,11 @@
 // https://nodejs.org/api/crypto.html
 // https://github.com/unjs/uncrypto
 import type nodeCrypto from "node:crypto";
-import { notImplemented } from "src/runtime/_internal/utils";
+import { Buffer } from "../buffer";
+
+// limit of Crypto.getRandomValues()
+// https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
+const MAX_BYTES: number = 65_536;
 
 const webcrypto = globalThis.crypto;
 
@@ -17,7 +21,27 @@ export const getRandomValues: typeof nodeCrypto.getRandomValues = (
   return webcrypto.getRandomValues(array);
 };
 
-export const randomBytes = notImplemented("webcrypto.randomBytes");
+type randomBytesCallback = (err: null, buffer: Uint8Array) => void;
+export const randomBytes: typeof nodeCrypto.randomBytes = (
+  size: number,
+  cb: randomBytesCallback
+) => {
+  const bytes = Buffer.allocUnsafe(size);
+
+  for (let generated = 0; generated < size; generated += MAX_BYTES) {
+    // buffer.slice automatically checks if the end is past the end of
+    // the buffer so we don't have to here
+    getRandomValues(bytes.slice(generated, generated + MAX_BYTES));
+  }
+
+  if (typeof cb === "function") {
+    return process.nextTick(function () {
+      cb(null, bytes);
+    });
+  }
+
+  return bytes;
+};
 
 // TODO: Add missing exports (typecheck is not working!)
 export default <typeof nodeCrypto>{

--- a/src/runtime/node/crypto/index.ts
+++ b/src/runtime/node/crypto/index.ts
@@ -20,18 +20,23 @@ export const getRandomValues: typeof nodeCrypto.getRandomValues = (
   return webcrypto.getRandomValues(array);
 };
 
-export const randomBytes /* :typeof nodeCrypto.randomBytes */ = (size: number, cb?: (err: Error | null, buf: Buffer) => void) => {
+export const randomBytes /* :typeof nodeCrypto.randomBytes */ = (
+  size: number,
+  cb?: (err: Error | null, buf: Buffer) => void
+) => {
   const bytes = Buffer.alloc(size, 0, undefined) as Buffer;
 
   for (let generated = 0; generated < size; generated += MAX_BYTES) {
     // buffer.slice automatically checks if the end is past the end of
     // the buffer so we don't have to here
-    getRandomValues(Uint8Array.prototype.slice.call(bytes, generated, generated + MAX_BYTES));
+    getRandomValues(
+      Uint8Array.prototype.slice.call(bytes, generated, generated + MAX_BYTES)
+    );
   }
 
   if (typeof cb === "function") {
-    cb(null, bytes)
-    return
+    cb(null, bytes);
+    return;
   }
   return bytes;
 };


### PR DESCRIPTION
Added export of `randomBytes` to the crypto polyfill.  If another dependency requires it currently, nitro will fail to build. Currently webcrypto does not have a `randomBytes` method

```
[nitro 2:36:51 PM]  ERROR  RollupError: "randomBytes" is not exported by "node_modules/unenv/runtime/node/crypto/index.mjs", imported by "node_modules/@firebase/firestore/dist/lite/index.node.mjs".


5: import { FirebaseError, getDefaultEmulatorHostnameAndPort, createMockUserToken, getModularInstance, deepEqual } from ...
6: import nodeFetch from 'node-fetch';
7: import { randomBytes as randomBytes$1 } from 'crypto';
            ^
8:
9: const version$1 = "3.7.2";


 ERROR  "randomBytes" is not exported by "node_modules/unenv/runtime/node/crypto/index.mjs", imported by "node_modules/@firebase/firestore/dist/lite/index.node.mjs".
```