### PR TITLE
fix(node): preserve http number header type with `setHeader` 

### DIFF
--- a/src/runtime/fetch/index.ts
+++ b/src/runtime/fetch/index.ts
@@ -20,7 +20,7 @@ export function createFetch(call: CallHandle, _fetch = global.fetch) {
         headers: Object.fromEntries(
           Object.entries(r.headers).map(([name, value]) => [
             name,
-            Array.isArray(value) ? value.join(",") : value || "",
+            Array.isArray(value) ? value.join(",") : String(value) || "",
           ]),
         ),
       });

--- a/src/runtime/node/http/_response.ts
+++ b/src/runtime/node/http/_response.ts
@@ -22,7 +22,7 @@ export class ServerResponse extends Writable implements http.ServerResponse {
 
   req: http.IncomingMessage;
 
-  _headers: HeadersObject = {};
+  _headers: Record<string, number | string | string[] | undefined> = {};
 
   constructor(req: http.IncomingMessage) {
     super();
@@ -91,12 +91,12 @@ export class ServerResponse extends Writable implements http.ServerResponse {
     return this;
   }
 
-  setHeader(name: string, value: string | string[]): this {
+  setHeader(name: string, value: number | string | string[]): this {
     this._headers[name.toLowerCase()] = value;
     return this;
   }
 
-  getHeader(name: string): string | string[] | undefined {
+  getHeader(name: string): number | string | string[] | undefined {
     return this._headers[name.toLowerCase()];
   }
 

--- a/src/runtime/node/http/_response.ts
+++ b/src/runtime/node/http/_response.ts
@@ -91,15 +91,12 @@ export class ServerResponse extends Writable implements http.ServerResponse {
     return this;
   }
 
-  setHeader(
-    name: string,
-    value: number | string | ReadonlyArray<string>,
-  ): this {
-    this._headers[name.toLowerCase()] = value + "";
+  setHeader(name: string, value: string | string[]): this {
+    this._headers[name.toLowerCase()] = value;
     return this;
   }
 
-  getHeader(name: string): number | string | string[] | undefined {
+  getHeader(name: string): string | string[] | undefined {
     return this._headers[name.toLowerCase()];
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

fix https://github.com/unjs/unenv/issues/118

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR changes the odd unenv behaviour that joined multiple value headers instead of preserving the array.
This brings `setHeader` behaviour in line with `appendHeader` when it comes to multiple values headers.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
