### PR TITLE
fix(node:crypto): properly call web crypto methods

### DIFF
--- a/src/runtime/node/crypto/node.ts
+++ b/src/runtime/node/crypto/node.ts
@@ -7,6 +7,19 @@ import { getRandomValues } from "./web";
 // https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
 const MAX_RANDOM_VALUE_BYTES: number = 65_536;
 
+// Node.js webcrypto implementation
+export const webcrypto = new Proxy(
+  globalThis.crypto as Crypto & typeof nodeCrypto.webcrypto,
+  {
+    get(_, key: keyof typeof globalThis.crypto | "CryptoKey") {
+      if (key === "CryptoKey") {
+        return globalThis.CryptoKey;
+      }
+      return globalThis.crypto[key];
+    },
+  },
+);
+
 // ---- implemented Utils ----
 
 export const randomBytes: typeof nodeCrypto.randomBytes = (

--- a/src/runtime/node/crypto/node.ts
+++ b/src/runtime/node/crypto/node.ts
@@ -7,7 +7,8 @@ import { getRandomValues } from "./web";
 // https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
 const MAX_RANDOM_VALUE_BYTES: number = 65_536;
 
-// Node.js webcrypto implementation
+// ---- implemented Utils ----
+
 export const webcrypto = new Proxy(
   globalThis.crypto as typeof nodeCrypto.webcrypto,
   {
@@ -19,8 +20,6 @@ export const webcrypto = new Proxy(
     },
   },
 );
-
-// ---- implemented Utils ----
 
 export const randomBytes: typeof nodeCrypto.randomBytes = (
   size: number,

--- a/src/runtime/node/crypto/node.ts
+++ b/src/runtime/node/crypto/node.ts
@@ -9,7 +9,7 @@ const MAX_RANDOM_VALUE_BYTES: number = 65_536;
 
 // Node.js webcrypto implementation
 export const webcrypto = new Proxy(
-  globalThis.crypto as Crypto & typeof nodeCrypto.webcrypto,
+  globalThis.crypto as typeof nodeCrypto.webcrypto,
   {
     get(_, key: keyof typeof globalThis.crypto | "CryptoKey") {
       if (key === "CryptoKey") {

--- a/src/runtime/node/crypto/web.ts
+++ b/src/runtime/node/crypto/web.ts
@@ -5,10 +5,16 @@ import type nodeCrypto from "node:crypto";
 export const CryptoKey =
   globalThis.CryptoKey as unknown as typeof nodeCrypto.webcrypto.CryptoKey;
 
-export const webcrypto: Crypto & typeof nodeCrypto.webcrypto = {
-  CryptoKey,
-  ...globalThis.crypto,
-};
+function ensureBound(thisArg: any, name: string | symbol) {
+  const fn = thisArg[name];
+  return typeof fn === "function" ? fn.bind(thisArg) : fn;
+}
+
+export const webcrypto: Crypto & typeof nodeCrypto.webcrypto = new Proxy<Crypto & typeof nodeCrypto.webcrypto>({} as any, {
+  get(target, name) {
+    return CryptoKey && (CryptoKey as any)[name] ? ensureBound(CryptoKey, name) : ensureBound(globalThis.crypto, name);
+  },
+});
 
 export const subtle: SubtleCrypto = webcrypto.subtle;
 

--- a/src/runtime/node/crypto/web.ts
+++ b/src/runtime/node/crypto/web.ts
@@ -1,27 +1,12 @@
 // https://nodejs.org/api/crypto.html
 // https://github.com/unjs/uncrypto
-import type nodeCrypto from "node:crypto";
 
-export const CryptoKey =
-  globalThis.CryptoKey as unknown as typeof nodeCrypto.webcrypto.CryptoKey;
-
-function ensureBound(thisArg: any, name: string | symbol) {
-  const fn = thisArg[name];
-  return typeof fn === "function" ? fn.bind(thisArg) : fn;
-}
-
-export const webcrypto: Crypto & typeof nodeCrypto.webcrypto = new Proxy<Crypto & typeof nodeCrypto.webcrypto>({} as any, {
-  get(target, name) {
-    return CryptoKey && (CryptoKey as any)[name] ? ensureBound(CryptoKey, name) : ensureBound(globalThis.crypto, name);
-  },
-});
-
-export const subtle: SubtleCrypto = webcrypto.subtle;
+export const subtle: SubtleCrypto = globalThis.crypto?.subtle;
 
 export const randomUUID: Crypto["randomUUID"] = () => {
-  return webcrypto.randomUUID();
+  return globalThis.crypto?.randomUUID();
 };
 
 export const getRandomValues: Crypto["getRandomValues"] = (array: any) => {
-  return webcrypto.getRandomValues(array);
+  return globalThis.crypto?.getRandomValues(array);
 };


### PR DESCRIPTION
The latest change broke some Nuxt deployments to Deno deploy for me. Deno's webcrypto is somewhat different, and `...globalThis.crypto` does not work in Deno. This replaces it with a custom getter that retrieves the correct value instead. This adds some overhead, but is required for Deno compatibility.

![grafik](https://github.com/unjs/unenv/assets/67546953/4fa993e0-c0bf-4333-b41d-db60711667d0)
