### PR TITLE
feat: expose `__unenv__` flag for unenv classes and functions

### DIFF
--- a/src/runtime/_internal/utils.ts
+++ b/src/runtime/_internal/utils.ts
@@ -24,13 +24,15 @@ export function mergeFns(...functions: Fn[]) {
 }
 
 export function notImplemented(name: string) {
-  return (): any => {
+  const fn = (): any => {
     throw new Error(`[unenv] ${name} is not implemented yet!`);
   };
+  return Object.assign(fn, { __unenv__: true });
 }
 
 export function notImplementedClass(name: string) {
   return class {
+    readonly __unenv__ = true;
     constructor() {
       throw new Error(`[unenv] ${name} is not implemented yet!`);
     }

--- a/src/runtime/mock/empty.ts
+++ b/src/runtime/mock/empty.ts
@@ -1,1 +1,5 @@
-export default {};
+export default Object.freeze(
+  Object.create(null, {
+    __unenv__: { get: () => true },
+  }),
+);

--- a/src/runtime/mock/noop.ts
+++ b/src/runtime/mock/noop.ts
@@ -1,1 +1,1 @@
-export default () => {};
+export default Object.assign(() => {}, { __unenv__: true });

--- a/src/runtime/mock/proxy.ts
+++ b/src/runtime/mock/proxy.ts
@@ -11,6 +11,9 @@ function createMock(name: string, overrides: any = {}): any {
       if (prop === "__createMock__") {
         return createMock;
       }
+      if (prop === "__unenv__") {
+        return true;
+      }
       if (prop in overrides) {
         return overrides[prop];
       }

--- a/src/runtime/node/async_hooks/_async-hook.ts
+++ b/src/runtime/node/async_hooks/_async-hook.ts
@@ -3,6 +3,8 @@ import type asyncHooks from "node:async_hooks";
 // https://nodejs.org/api/async_hooks.html
 
 export class AsyncHook implements asyncHooks.HookCallbacks {
+  readonly __unenv__ = true;
+
   _enabled: boolean = false;
   _callbacks: asyncHooks.HookCallbacks = {};
 

--- a/src/runtime/node/async_hooks/_async-local-storage.ts
+++ b/src/runtime/node/async_hooks/_async-local-storage.ts
@@ -3,6 +3,8 @@ import type asyncHooks from "node:async_hooks";
 // https://nodejs.org/api/async_context.html#class-asynclocalstorage
 
 export class AsyncLocalStorage<T> implements asyncHooks.AsyncLocalStorage<T> {
+  readonly __unenv__ = true;
+
   _currentStore: undefined | T;
   _enterStore: undefined | T;
   _enabled: boolean = true;

--- a/src/runtime/node/async_hooks/_async-resource.ts
+++ b/src/runtime/node/async_hooks/_async-resource.ts
@@ -6,6 +6,8 @@ import { executionAsyncId } from "./_async-hook";
 let _asyncIdCounter = 100;
 
 export class AsyncResource implements asyncHooks.AsyncResource {
+  readonly __unenv__ = true;
+
   type: string;
   _asyncId: undefined | number;
   _triggerAsyncId: undefined | number | asyncHooks.AsyncResourceOptions;

--- a/src/runtime/node/buffer/_file.ts
+++ b/src/runtime/node/buffer/_file.ts
@@ -2,6 +2,8 @@ import type buffer from "node:buffer";
 import { Buffer } from "./_buffer";
 
 export class File extends Blob implements buffer.File {
+  readonly __unenv__ = true;
+
   size: number = 0;
   type: any = "";
   name: string = "";

--- a/src/runtime/node/http/_request.ts
+++ b/src/runtime/node/http/_request.ts
@@ -7,6 +7,8 @@ import { rawHeaders } from "../../_internal/utils";
 // Implementation: https://github.com/nodejs/node/blob/master/lib/_http_incoming.js
 
 export class IncomingMessage extends Readable implements http.IncomingMessage {
+  readonly __unenv__ = true;
+
   public aborted: boolean = false;
   public httpVersion: string = "1.1";
   public httpVersionMajor: number = 1;

--- a/src/runtime/node/http/_request.ts
+++ b/src/runtime/node/http/_request.ts
@@ -7,7 +7,7 @@ import { rawHeaders } from "../../_internal/utils";
 // Implementation: https://github.com/nodejs/node/blob/master/lib/_http_incoming.js
 
 export class IncomingMessage extends Readable implements http.IncomingMessage {
-  readonly __unenv__ = true;
+  public __unenv__ = {};
 
   public aborted: boolean = false;
   public httpVersion: string = "1.1";

--- a/src/runtime/node/http/_response.ts
+++ b/src/runtime/node/http/_response.ts
@@ -7,6 +7,8 @@ import { Writable } from "../stream/writable";
 // Implementation: https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js
 
 export class ServerResponse extends Writable implements http.ServerResponse {
+  readonly __unenv__ = true;
+
   statusCode: number = 200;
   statusMessage: string = "";
   upgrading: boolean = false;

--- a/src/runtime/node/net/socket.ts
+++ b/src/runtime/node/net/socket.ts
@@ -4,6 +4,8 @@ import { Duplex } from "../stream/duplex";
 
 // Docs: https://nodejs.org/api/net.html#net_class_net_socket
 export class Socket extends Duplex implements net.Socket {
+  readonly __unenv__ = true;
+
   readonly bufferSize: number = 0;
   readonly bytesRead: number = 0;
   readonly bytesWritten: number = 0;
@@ -90,6 +92,8 @@ export class Socket extends Duplex implements net.Socket {
 }
 
 export class SocketAddress implements net.SocketAddress {
+  readonly __unenv__ = true;
+
   address: string;
   family: "ipv4" | "ipv6";
   port: number;

--- a/src/runtime/node/stream/readable.ts
+++ b/src/runtime/node/stream/readable.ts
@@ -8,7 +8,7 @@ import { EventEmitter } from "../events";
 
 // eslint-disable-next-line unicorn/prefer-event-target
 export class Readable extends EventEmitter implements stream.Readable {
-  readonly __unenv__ = true;
+  __unenv__: unknown = true;
 
   readonly readableEncoding: BufferEncoding | null = null;
   readonly readableEnded: boolean = true;

--- a/src/runtime/node/stream/readable.ts
+++ b/src/runtime/node/stream/readable.ts
@@ -8,6 +8,8 @@ import { EventEmitter } from "../events";
 
 // eslint-disable-next-line unicorn/prefer-event-target
 export class Readable extends EventEmitter implements stream.Readable {
+  readonly __unenv__ = true;
+
   readonly readableEncoding: BufferEncoding | null = null;
   readonly readableEnded: boolean = true;
   readonly readableFlowing: boolean | null = false;

--- a/src/runtime/node/stream/transform.ts
+++ b/src/runtime/node/stream/transform.ts
@@ -5,6 +5,8 @@ import { Duplex } from "./duplex";
 // Implementation: https://github.com/nodejs/node/blob/master/lib/internal/streams/transform.js
 
 export class Transform extends Duplex implements stream.Transform {
+  readonly __unenv__ = true;
+
   _transform(
     chunk: any,
     encoding: globalThis.BufferEncoding,

--- a/src/runtime/node/stream/writable.ts
+++ b/src/runtime/node/stream/writable.ts
@@ -7,6 +7,8 @@ import { EventEmitter } from "../events";
 // Implementation: https://github.com/nodejs/node/blob/master/lib/internal/streams/writable.js
 // eslint-disable-next-line unicorn/prefer-event-target
 export class Writable extends EventEmitter implements stream.Writable {
+  readonly __unenv__ = true;
+
   readonly writable: boolean = true;
   writableEnded: boolean = false;
   writableFinished: boolean = false;

--- a/src/runtime/node/util/_mime.ts
+++ b/src/runtime/node/util/_mime.ts
@@ -6,6 +6,8 @@ import type {
 // https://nodejs.org/api/util.html#class-utilmimetype
 
 export class MIMEType implements MIMETypeT {
+  readonly __unenv__ = true;
+
   params = new MIMEParams();
   type: string;
   subtype: string;
@@ -35,6 +37,8 @@ export class MIMEType implements MIMETypeT {
 // https://nodejs.org/api/util.html#util_class_util_mimeparams
 
 export class MIMEParams extends Map<string, string> implements MIMEParamsT {
+  readonly __unenv__ = true;
+
   get(name: string) {
     return (super.get(name) || null) as any;
   }


### PR DESCRIPTION

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

it is commonly required to identify if something is coming from unenv or not specially for classes and mocked objects. 

This PR adds `__unenv__` property to class (instances) and functions to identify.

**Note:** Since we were already using `req.__unenv__` for another purpose (https://github.com/unjs/unenv/issues/72), the type for `IncommingMessage` and `Readable` classes is unknown/object.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
