### PR TITLE
feat(node:async_hooks): allow overriding `AsyncHook`, `AsyncLocalStorage` and `AsyncResource` with `globalThis`

### DIFF
--- a/src/runtime/node/async_hooks/_async-hook.ts
+++ b/src/runtime/node/async_hooks/_async-hook.ts
@@ -2,7 +2,7 @@ import type asyncHooks from "node:async_hooks";
 
 // https://nodejs.org/api/async_hooks.html
 
-export class AsyncHook implements asyncHooks.HookCallbacks {
+class _AsyncHook implements asyncHooks.HookCallbacks {
   readonly __unenv__ = true;
 
   _enabled: boolean = false;
@@ -52,6 +52,9 @@ export class AsyncHook implements asyncHooks.HookCallbacks {
     }
   }
 }
+
+export const AsyncHook: asyncHooks.AsyncHook =
+  (globalThis as any).AsyncHook || _AsyncHook;
 
 export const createHook: typeof asyncHooks.createHook = function createHook(
   callbacks,

--- a/src/runtime/node/async_hooks/_async-local-storage.ts
+++ b/src/runtime/node/async_hooks/_async-local-storage.ts
@@ -2,7 +2,7 @@ import type asyncHooks from "node:async_hooks";
 
 // https://nodejs.org/api/async_context.html#class-asynclocalstorage
 
-export class AsyncLocalStorage<T> implements asyncHooks.AsyncLocalStorage<T> {
+class _AsyncLocalStorage<T> implements asyncHooks.AsyncLocalStorage<T> {
   readonly __unenv__ = true;
 
   _currentStore: undefined | T;
@@ -51,3 +51,6 @@ export class AsyncLocalStorage<T> implements asyncHooks.AsyncLocalStorage<T> {
     throw new Error("[unenv] `AsyncLocalStorage.snapshot` is not implemented!");
   }
 }
+
+export const AsyncLocalStorage: typeof asyncHooks.AsyncLocalStorage =
+  (globalThis as any).AsyncLocalStorage || _AsyncLocalStorage;

--- a/src/runtime/node/async_hooks/_async-resource.ts
+++ b/src/runtime/node/async_hooks/_async-resource.ts
@@ -5,7 +5,7 @@ import { executionAsyncId } from "./_async-hook";
 
 let _asyncIdCounter = 100;
 
-export class AsyncResource implements asyncHooks.AsyncResource {
+class _AsyncResource implements asyncHooks.AsyncResource {
   readonly __unenv__ = true;
 
   type: string;
@@ -63,3 +63,6 @@ export class AsyncResource implements asyncHooks.AsyncResource {
     return this._triggerAsyncId as number;
   }
 }
+
+export const AsyncResource: typeof asyncHooks.AsyncResource =
+  (globalThis as any).AsyncResource || _AsyncResource;


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

allow overriding `AsyncHook`, `AsyncLocalStorage` and `AsyncResource` with `globalThis` and platform natives.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
