### PR TITLE
refactor(node:events): rewrite `EventEmitter`

### DIFF
--- a/src/runtime/node/events/_events.ts
+++ b/src/runtime/node/events/_events.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Source: https://github.com/browserify/events/blob/48e3d18659caf72d94d319871106f089bb40002d/events.js
 // Copyright Joyent, Inc. and other Node contributors.
 //
@@ -21,74 +20,31 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const R = typeof Reflect === "object" ? Reflect : null;
-const ReflectApply =
-  R && typeof R.apply === "function"
-    ? R.apply
-    : function ReflectApply(target, receiver, args) {
-        return Function.prototype.apply.call(target, receiver, args);
-      };
+import type nodeEvents from "node:events";
 
-let ReflectOwnKeys;
-if (R && typeof R.ownKeys === "function") {
-  ReflectOwnKeys = R.ownKeys;
-} else if (Object.getOwnPropertySymbols) {
-  ReflectOwnKeys = function ReflectOwnKeys(target) {
-    return [
-      ...Object.getOwnPropertyNames(target),
-      ...Object.getOwnPropertySymbols(target),
-    ];
-  };
-} else {
-  ReflectOwnKeys = function ReflectOwnKeys(target) {
-    return Object.getOwnPropertyNames(target);
-  };
+interface Listener {
+  (...args: any[]): void;
+  listener?: (...args: any[]) => void;
 }
-
-function ProcessEmitWarning(warning) {
-  if (console && console.warn) {
-    console.warn(warning);
-  }
-}
-
-const NumberIsNaN =
-  Number.isNaN ||
-  function NumberIsNaN(value) {
-    // eslint-disable-next-line no-self-compare
-    return value !== value;
-  };
-
-export function EventEmitter() {
-  EventEmitter.init.call(this);
-}
-
-// Backwards-compat with node 0.10.x
-EventEmitter.EventEmitter = EventEmitter;
-
-EventEmitter.prototype._events = undefined;
-EventEmitter.prototype._eventsCount = 0;
-EventEmitter.prototype._maxListeners = undefined;
 
 // By default EventEmitters will print a warning if more than 10 listeners are
 // added to it. This is a useful default which helps finding memory leaks.
 let defaultMaxListeners = 10;
 
-function checkListener(listener) {
-  if (typeof listener !== "function") {
-    throw new TypeError(
-      'The "listener" argument must be of type Function. Received type ' +
-        typeof listener,
-    );
-  }
-}
+export class EventEmitter implements nodeEvents.EventEmitter {
+  readonly __unenv__ = true;
 
-Object.defineProperty(EventEmitter, "defaultMaxListeners", {
-  enumerable: true,
-  get: function () {
+  _events: Record<string, Listener[] & { warned?: boolean }> =
+    Object.create(null);
+
+  _maxListeners: undefined | number;
+
+  static get defaultMaxListeners() {
     return defaultMaxListeners;
-  },
-  set: function (arg) {
-    if (typeof arg !== "number" || arg < 0 || NumberIsNaN(arg)) {
+  }
+
+  static set defaultMaxListeners(arg) {
+    if (typeof arg !== "number" || arg < 0 || Number.isNaN(arg)) {
       throw new RangeError(
         'The value of "defaultMaxListeners" is out of range. It must be a non-negative number. Received ' +
           arg +
@@ -96,417 +52,109 @@ Object.defineProperty(EventEmitter, "defaultMaxListeners", {
       );
     }
     defaultMaxListeners = arg;
-  },
-});
-
-EventEmitter.init = function () {
-  if (
-    this._events === undefined ||
-    this._events === Object.getPrototypeOf(this)._events
-  ) {
-    this._events = Object.create(null);
-    this._eventsCount = 0;
   }
 
-  this._maxListeners = this._maxListeners || undefined;
-};
-
-// Obviously not all Emitters should be limited to 10. This function allows
-// that to be increased. Set to zero for unlimited.
-EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {
-  if (typeof n !== "number" || n < 0 || NumberIsNaN(n)) {
-    throw new RangeError(
-      'The value of "n" is out of range. It must be a non-negative number. Received ' +
-        n +
-        ".",
-    );
-  }
-  this._maxListeners = n;
-  return this;
-};
-
-function _getMaxListeners(that) {
-  if (that._maxListeners === undefined) {
-    return EventEmitter.defaultMaxListeners;
-  }
-  return that._maxListeners;
-}
-
-EventEmitter.prototype.getMaxListeners = function getMaxListeners() {
-  return _getMaxListeners(this);
-};
-
-EventEmitter.prototype.emit = function emit(type) {
-  const args = [];
-  for (let i = 1; i < arguments.length; i++) {
-    args.push(arguments[i]);
-  }
-  let doError = type === "error";
-
-  const events = this._events;
-  if (events !== undefined) {
-    doError = doError && events.error === undefined;
-  } else if (!doError) {
-    return false;
-  }
-
-  // If there is no 'error' event listener then throw.
-  if (doError) {
-    let er;
-    if (args.length > 0) {
-      er = args[0];
-    }
-    if (er instanceof Error) {
-      // Note: The comments on the `throw` lines are intentional, they show
-      // up in Node's output if this results in an unhandled exception.
-      throw er; // Unhandled 'error' event
-    }
-    // At least give some kind of context to the user
-    const err = new Error(
-      "Unhandled error." + (er ? " (" + er.message + ")" : ""),
-    );
-    err.context = er;
-    throw err; // Unhandled 'error' event
-  }
-
-  const handler = events[type];
-
-  if (handler === undefined) {
-    return false;
-  }
-
-  if (typeof handler === "function") {
-    ReflectApply(handler, this, args);
-  } else {
-    const len = handler.length;
-    const listeners = arrayClone(handler, len);
-    for (let i = 0; i < len; ++i) {
-      ReflectApply(listeners[i], this, args);
-    }
-  }
-
-  return true;
-};
-
-function _addListener(target, type, listener, prepend) {
-  let m;
-  let events;
-  let existing;
-
-  checkListener(listener);
-
-  events = target._events;
-  if (events === undefined) {
-    events = target._events = Object.create(null);
-    target._eventsCount = 0;
-  } else {
-    // To avoid recursion in the case that type === "newListener"! Before
-    // adding it to the listeners, first emit "newListener".
-    if (events.newListener !== undefined) {
-      target.emit(
-        "newListener",
-        type,
-        // eslint-disable-next-line unicorn/prefer-logical-operator-over-ternary
-        listener.listener ? listener.listener : listener,
+  setMaxListeners(n: number) {
+    if (typeof n !== "number" || n < 0 || Number.isNaN(n)) {
+      throw new RangeError(
+        'The value of "n" is out of range. It must be a non-negative number. Received ' +
+          n +
+          ".",
       );
-
-      // Re-assign `events` because a newListener handler could have caused the
-      // this._events to be assigned to a new object
-      events = target._events;
     }
-    existing = events[type];
-  }
-
-  if (existing === undefined) {
-    // Optimize the case of one listener. Don't need the extra array object.
-    existing = events[type] = listener;
-    ++target._eventsCount;
-  } else {
-    if (typeof existing === "function") {
-      // Adding the second element, need to change to array.
-      existing = events[type] = prepend
-        ? [listener, existing]
-        : [existing, listener];
-      // If we've already got an array, just append.
-    } else if (prepend) {
-      existing.unshift(listener);
-    } else {
-      existing.push(listener);
-    }
-
-    // Check for listener leak
-    m = _getMaxListeners(target);
-    if (m > 0 && existing.length > m && !existing.warned) {
-      existing.warned = true;
-      // No error code for this since it is a Warning
-      // eslint-disable-next-line no-restricted-syntax
-      const w = new Error(
-        "Possible EventEmitter memory leak detected. " +
-          existing.length +
-          " " +
-          String(type) +
-          " listeners " +
-          "added. Use emitter.setMaxListeners() to " +
-          "increase limit",
-      );
-      w.name = "MaxListenersExceededWarning";
-      w.emitter = target;
-      w.type = type;
-      w.count = existing.length;
-      ProcessEmitWarning(w);
-    }
-  }
-
-  return target;
-}
-
-EventEmitter.prototype.addListener = function addListener(type, listener) {
-  return _addListener(this, type, listener, false);
-};
-
-EventEmitter.prototype.on = EventEmitter.prototype.addListener;
-
-EventEmitter.prototype.prependListener = function prependListener(
-  type,
-  listener,
-) {
-  return _addListener(this, type, listener, true);
-};
-
-function onceWrapper() {
-  if (!this.fired) {
-    this.target.removeListener(this.type, this.wrapFn);
-    this.fired = true;
-    if (arguments.length === 0) {
-      return this.listener.call(this.target);
-    }
-    return this.listener.apply(this.target, arguments);
-  }
-}
-
-function _onceWrap(target, type, listener) {
-  const state = { fired: false, wrapFn: undefined, target, type, listener };
-  const wrapped = onceWrapper.bind(state);
-  wrapped.listener = listener;
-  state.wrapFn = wrapped;
-  return wrapped;
-}
-
-EventEmitter.prototype.once = function once(type, listener) {
-  checkListener(listener);
-  this.on(type, _onceWrap(this, type, listener));
-  return this;
-};
-
-EventEmitter.prototype.prependOnceListener = function prependOnceListener(
-  type,
-  listener,
-) {
-  checkListener(listener);
-  this.prependListener(type, _onceWrap(this, type, listener));
-  return this;
-};
-
-// Emits a 'removeListener' event if and only if the listener was removed.
-EventEmitter.prototype.removeListener = function removeListener(
-  type,
-  listener,
-) {
-  let position, i, originalListener;
-
-  checkListener(listener);
-
-  const events = this._events;
-  if (events === undefined) {
+    this._maxListeners = n;
     return this;
   }
 
-  const list = events[type];
-  if (list === undefined) {
-    return this;
+  getMaxListeners() {
+    return _getMaxListeners(this);
   }
 
-  if (list === listener || list.listener === listener) {
-    if (--this._eventsCount === 0) {
-      this._events = Object.create(null);
-    } else {
-      delete events[type];
-      if (events.removeListener) {
-        this.emit("removeListener", type, list.listener || listener);
+  emit(type: string, ...args: any[]) {
+    if (!this._events[type] || this._events[type].length === 0) {
+      return false;
+    }
+
+    // If there is no 'error' event listener then throw.
+    if (type === "error") {
+      let er;
+      if (args.length > 0) {
+        er = args[0];
       }
-    }
-  } else if (typeof list !== "function") {
-    position = -1;
-
-    for (i = list.length - 1; i >= 0; i--) {
-      if (list[i] === listener || list[i].listener === listener) {
-        originalListener = list[i].listener;
-        position = i;
-        break;
+      if (er instanceof Error) {
+        // Note: The comments on the `throw` lines are intentional, they show
+        // up in Node's output if this results in an unhandled exception.
+        throw er; // Unhandled 'error' event
       }
+      // At least give some kind of context to the user
+      const err = new Error(
+        "Unhandled error." + (er ? " (" + er.message + ")" : ""),
+      ) as Error & { context?: Error };
+      err.context = er;
+      throw err; // Unhandled 'error' event
     }
 
-    if (position < 0) {
-      return this;
+    for (const _listener of this._events[type]) {
+      (_listener.listener || _listener).apply(this, args);
     }
 
-    if (position === 0) {
-      list.shift();
-    } else {
-      spliceOne(list, position);
-    }
-
-    if (list.length === 1) {
-      events[type] = list[0];
-    }
-
-    if (events.removeListener !== undefined) {
-      this.emit("removeListener", type, originalListener || listener);
-    }
+    return true;
   }
 
-  return this;
-};
-
-EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
-
-EventEmitter.prototype.removeAllListeners = function removeAllListeners(type) {
-  let i;
-
-  const events = this._events;
-  if (events === undefined) {
-    return this;
+  addListener(type: string, listener: Listener) {
+    return _addListener(this, type, listener, false);
   }
 
-  // not listening for removeListener, no need to emit
-  if (events.removeListener === undefined) {
-    if (arguments.length === 0) {
-      this._events = Object.create(null);
-      this._eventsCount = 0;
-    } else if (events[type] !== undefined) {
-      if (--this._eventsCount === 0) {
-        this._events = Object.create(null);
-      } else {
-        delete events[type];
-      }
-    }
-    return this;
+  on(type: string, listener: Listener) {
+    return _addListener(this, type, listener, false);
   }
 
-  // emit removeListener for all listeners on all events
-  if (arguments.length === 0) {
-    const keys = Object.keys(events);
-    let key;
-    for (i = 0; i < keys.length; ++i) {
-      key = keys[i];
-      if (key === "removeListener") {
-        continue;
-      }
-      this.removeAllListeners(key);
-    }
-    this.removeAllListeners("removeListener");
-    this._events = Object.create(null);
-    this._eventsCount = 0;
-    return this;
+  prependListener(type: string, listener: Listener) {
+    return _addListener(this, type, listener, true);
   }
 
-  const listeners = events[type];
-
-  if (typeof listeners === "function") {
-    this.removeListener(type, listeners);
-  } else if (listeners !== undefined) {
-    // LIFO order
-    for (i = listeners.length - 1; i >= 0; i--) {
-      this.removeListener(type, listeners[i]);
-    }
+  once(type: string, listener: Listener) {
+    return this.on(type, _wrapOnce(this, type, listener));
   }
 
-  return this;
-};
-
-function _listeners(target, type, unwrap) {
-  const events = target._events;
-
-  if (events === undefined) {
-    return [];
+  prependOnceListener(type: string, listener: Listener) {
+    return this.prependListener(type, _wrapOnce(this, type, listener));
   }
 
-  const evlistener = events[type];
-  if (evlistener === undefined) {
-    return [];
+  removeListener(type: string, listener: Listener) {
+    return _removeListener(this, type, listener);
   }
 
-  if (typeof evlistener === "function") {
-    return unwrap ? [evlistener.listener || evlistener] : [evlistener];
+  off(type: string, listener: Listener) {
+    return this.removeListener(type, listener);
   }
 
-  return unwrap
-    ? unwrapListeners(evlistener)
-    : arrayClone(evlistener, evlistener.length);
+  removeAllListeners(type: string) {
+    return _removeAllListeners(this, type);
+  }
+
+  listeners(type: string) {
+    return _listeners(this, type, true);
+  }
+
+  rawListeners(type: string) {
+    return _listeners(this, type, false);
+  }
+
+  listenerCount(type: string) {
+    return this.rawListeners(type).length;
+  }
+
+  eventNames() {
+    return Object.keys(this._events);
+  }
 }
 
-EventEmitter.prototype.listeners = function listeners(type) {
-  return _listeners(this, type, true);
-};
+// --- Utils ---
 
-EventEmitter.prototype.rawListeners = function rawListeners(type) {
-  return _listeners(this, type, false);
-};
-
-EventEmitter.listenerCount = function (emitter, type) {
-  return typeof emitter.listenerCount === "function"
-    ? emitter.listenerCount(type)
-    : listenerCount.call(emitter, type);
-};
-
-EventEmitter.prototype.listenerCount = listenerCount;
-function listenerCount(type) {
-  const events = this._events;
-
-  if (events !== undefined) {
-    const evlistener = events[type];
-
-    if (typeof evlistener === "function") {
-      return 1;
-    } else if (evlistener !== undefined) {
-      return evlistener.length;
-    }
-  }
-
-  return 0;
-}
-
-EventEmitter.prototype.eventNames = function eventNames() {
-  return this._eventsCount > 0 ? ReflectOwnKeys(this._events) : [];
-};
-
-function arrayClone(arr, n) {
-  // eslint-disable-next-line unicorn/no-new-array
-  const copy = new Array(n);
-  for (let i = 0; i < n; ++i) {
-    copy[i] = arr[i];
-  }
-  return copy;
-}
-
-function spliceOne(list, index) {
-  for (; index + 1 < list.length; index++) {
-    list[index] = list[index + 1];
-  }
-  list.pop();
-}
-
-function unwrapListeners(arr) {
-  const ret = Array.from({ length: arr.length });
-  for (let i = 0; i < ret.length; ++i) {
-    ret[i] = arr[i].listener || arr[i];
-  }
-  return ret;
-}
-
-export function once(emitter, name) {
+export function once(emitter: EventEmitter, name: string) {
   return new Promise(function (resolve, reject) {
-    function errorListener(err) {
+    function errorListener(err: Error) {
       emitter.removeListener(name, resolver);
       reject(err);
     }
@@ -518,37 +166,167 @@ export function once(emitter, name) {
       resolve(Array.prototype.slice.call(arguments));
     }
 
-    eventTargetAgnosticAddListener(emitter, name, resolver, { once: true });
+    _eventTargetAgnosticAddListener(emitter, name, resolver, { once: true });
     if (name !== "error") {
-      addErrorHandlerIfEventEmitter(emitter, errorListener, { once: true });
+      _addErrorHandlerIfEventEmitter(emitter, errorListener, { once: true });
     }
   });
 }
 
-function addErrorHandlerIfEventEmitter(emitter, handler, flags) {
-  if (typeof emitter.on === "function") {
-    eventTargetAgnosticAddListener(emitter, "error", handler, flags);
+// --- Internal ---
+
+function _addListener<T extends EventEmitter>(
+  target: T,
+  type: string,
+  listener: Listener,
+  prepend: boolean,
+): T {
+  _checkListener(listener);
+
+  // To avoid recursion in the case that type === "newListener"! Before
+  // adding it to the listeners, first emit "newListener".
+  if (target._events.newListener !== undefined) {
+    target.emit("newListener", type, listener.listener || listener);
+  }
+
+  if (!target._events[type]) {
+    target._events[type] = [];
+  }
+
+  if (prepend) {
+    target._events[type].unshift(listener);
+  } else {
+    target._events[type].push(listener);
+  }
+
+  // Check for listener leak
+  const maxListeners = _getMaxListeners(target);
+  if (
+    maxListeners > 0 &&
+    target._events[type].length > maxListeners &&
+    !target._events[type].warned
+  ) {
+    target._events[type].warned = true;
+    // No error code for this since it is a Warning
+    // eslint-disable-next-line no-restricted-syntax
+    const warning = new Error(
+      `[unenv] Possible EventEmitter memory leak detected. ${target._events[type].length} ${type} listeners added. Use emitter.setMaxListeners() to increase limit`,
+    ) as Error & {
+      name?: string;
+      emitter?: EventEmitter;
+      type?: string;
+      count?: number;
+    };
+    warning.name = "MaxListenersExceededWarning";
+    warning.emitter = target;
+    warning.type = type;
+    warning.count = target._events[type]?.length;
+    console.warn(warning);
+  }
+
+  return target;
+}
+
+function _removeListener<T extends EventEmitter>(
+  target: T,
+  type: string,
+  listener: Listener,
+): T {
+  _checkListener(listener);
+  if (!target._events[type] || target._events[type].length === 0) {
+    return target;
+  }
+  const lenBeforeFilter = target._events[type].length;
+  target._events[type] = target._events[type].filter((fn) => fn !== listener);
+  if (lenBeforeFilter === target._events[type].length) {
+    return target;
+  }
+  if (target._events.removeListener) {
+    target.emit("removeListener", type, listener.listener || listener);
+  }
+  if (target._events[type].length === 0) {
+    delete target._events[type];
+  }
+  return target;
+}
+
+function _removeAllListeners<T extends EventEmitter>(
+  target: T,
+  type: string,
+): T {
+  if (!target._events[type] || target._events[type].length === 0) {
+    return target;
+  }
+  if (target._events.removeListener) {
+    for (const _listener of target._events[type]) {
+      target.emit("removeListener", type, _listener.listener || _listener);
+    }
+  }
+  delete target._events[type];
+  return target;
+}
+
+function _wrapOnce(target: EventEmitter, type: string, listener: Listener) {
+  let fired = false;
+  const wrapper: Listener = (...args) => {
+    if (fired) {
+      return;
+    }
+    target.removeListener(type, wrapper);
+    fired = true;
+    return args.length === 0
+      ? listener.call(target)
+      : listener.apply(target, args);
+  };
+  wrapper.listener = listener;
+  return wrapper;
+}
+
+function _getMaxListeners(target: EventEmitter) {
+  return target._maxListeners ?? EventEmitter.defaultMaxListeners;
+}
+
+function _listeners(target: EventEmitter, type: string, unwrap: boolean) {
+  let listeners = target._events[type];
+  if (typeof listeners === "function") {
+    listeners = [listeners];
+  }
+  return unwrap ? listeners.map((l) => l.listener || l) : listeners;
+}
+
+function _checkListener(listener: Listener) {
+  if (typeof listener !== "function") {
+    throw new TypeError(
+      'The "listener" argument must be of type Function. Received type ' +
+        typeof listener,
+    );
   }
 }
 
-function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
+function _addErrorHandlerIfEventEmitter(
+  emitter: EventEmitter,
+  handler: Listener,
+  flags: { once?: boolean },
+) {
   if (typeof emitter.on === "function") {
+    _eventTargetAgnosticAddListener(emitter, "error", handler, flags);
+  }
+}
+
+function _eventTargetAgnosticAddListener(
+  emitter: EventEmitter | EventTarget,
+  name: string,
+  listener: Listener,
+  flags: { once?: boolean },
+) {
+  if (typeof (emitter as EventEmitter).on === "function") {
     if (flags.once) {
-      emitter.once(name, listener);
+      (emitter as EventEmitter).once(name, listener);
     } else {
-      emitter.on(name, listener);
+      (emitter as EventEmitter).on(name, listener);
     }
-  } else if (typeof emitter.addEventListener === "function") {
-    // EventTarget does not have `error` event semantics like Node
-    // EventEmitters, we do not listen for `error` events here.
-    emitter.addEventListener(name, function wrapListener(arg) {
-      // IE does not have builtin `{ once: true }` support so we
-      // have to do it manually.
-      if (flags.once) {
-        emitter.removeEventListener(name, wrapListener);
-      }
-      listener(arg);
-    });
+  } else if (typeof (emitter as EventTarget).addEventListener === "function") {
+    (emitter as EventTarget).addEventListener(name, listener);
   } else {
     throw new TypeError(
       'The "emitter" argument must be of type EventEmitter. Received type ' +


### PR DESCRIPTION
- feat(node:buffer): allow overriding `Buffer` with `globalThis`
- feat(node:events): allow overriding `EventEmitter` with `globalThis`
- feat(node:stream): allow overriding `Duplex`, `Readable`, `Transform` and `Writable` with `globalThis`
- feat: add `node:string_decoder` with global polyfill
- ci: add typecheck
- ci: use node 18
- chore: fix type issues
- chore(release): v1.7.0
- refactor(node:events): rewrite `EventEmitter`

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Checking a bundle size increase issue with @danielroe, we found out that `EventEmitter` class (used by HTTP modules) is not side-effect free and when referencing it from h3 (only unused import) bundlers add it to the runtime.

This rewrites the class entirely with modern syntax and smaller code. (there are slight behavior changes but i guess they should be fine)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
