### PR TITLE
feat: experimental deno preset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.log*
 dist
 /runtime
+.tmp

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ const envConfig = env(nodeless, {});
 
 ### `deno` preset
 
+**Note:** This preset is **experimental** and behavior can change!
+
 This preset can be used to extend `nodeless` to use Deno's Node.js API Compatibility ([docs](https://docs.deno.com/runtime/manual/node/compatibility), [docs](https://docs.deno.com/deploy/api/runtime-node)).
 
 ```js

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const { alias, inject, polyfill, external } = env({}, {}, {});
 
 ### `node` preset
 
-Suitable to convert universal libraries working in Node.js. ([preset](./src/presets/node.ts))
+Suitable to convert universal libraries working in Node.js.
 
 - Add supports for global [`fetch` API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
 - Set Node.js built-ins as externals
@@ -40,9 +40,11 @@ import { env, nodeless } from "unenv";
 const envConfig = env(node, {});
 ```
 
+([view `node` preset source](./src/presets/node.ts))
+
 ### `nodeless` preset
 
-Using this preset, we can convert a code that is depending on Node.js to work anywhere else.
+Suitable to transform libraies made for Node.js to run in other JavaScript runtimes.
 
 ```js
 import { env, nodeless } from "unenv";
@@ -50,15 +52,19 @@ import { env, nodeless } from "unenv";
 const envConfig = env(nodeless, {});
 ```
 
+([view `nodeless` preset source](./src/presets/nodeless.ts))
+
 ### `deno` preset
 
-This preset can be used to extend `nodeless` to using Deno's Node API Compatibility ([docs](https://docs.deno.com/runtime/manual/node/compatibility) and [docs](https://docs.deno.com/deploy/api/runtime-node)) ([preset](./src/presets/deno.ts)).
+This preset can be used to extend `nodeless` to use Deno's Node.js API Compatibility ([docs](https://docs.deno.com/runtime/manual/node/compatibility), [docs](https://docs.deno.com/deploy/api/runtime-node)) ([view preset source](./src/presets/deno.ts)).
 
 ```js
 import { env, nodeless, deno } from "unenv";
 
 const envConfig = env(nodeless, deno, {});
 ```
+
+([view `deno` preset source](./src/presets/deno.ts))
 
 ### Built-in Node.js modules
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Suitable to convert universal libraries working in Node.js. ([preset](./src/pres
 
 Using this preset, we can convert a code that is depending on Node.js to work anywhere else.
 
+### `deno`
+
+This preset extends `nodeless` but allows using Deno's Node API Compatibility ([docs](https://docs.deno.com/runtime/manual/node/compatibility) and [docs](https://docs.deno.com/deploy/api/runtime-node)) ([preset](./src/presets/deno.ts)).
+
 ### Built-in Node.js modules
 
 `unenv` provides a replacement for all Node.js built-ins for cross-platform compatiblity.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # unenv
 
-`unenv` is a framework agnostic system that allows converting JavaScript code to be platform agnostic and working in any environment including Browsers, Workers, Node.js or pure JavaScript runtime.
+`unenv` is a framework-agnostic system that allows converting JavaScript code to be platform agnostic and work in any environment including Browsers, Workers, Node.js, or JavaScript runtime.
 
 ## Install
 
@@ -25,7 +25,7 @@ import { env } from "unenv";
 const { alias, inject, polyfill, external } = env({}, {}, {});
 ```
 
-**Note:** You can provide as many presets as you want. unenv will merge them internally and the right most preset has higher periority.
+**Note:** You can provide as many presets as you want. unenv will merge them internally and the right-most preset has a higher priority.
 
 ### `node` preset
 
@@ -44,7 +44,7 @@ const envConfig = env(node, {});
 
 ### `nodeless` preset
 
-Suitable to transform libraies made for Node.js to run in other JavaScript runtimes.
+Suitable to transform libraries made for Node.js to run in other JavaScript runtimes.
 
 ```js
 import { env, nodeless } from "unenv";
@@ -56,7 +56,7 @@ const envConfig = env(nodeless, {});
 
 ### `deno` preset
 
-This preset can be used to extend `nodeless` to use Deno's Node.js API Compatibility ([docs](https://docs.deno.com/runtime/manual/node/compatibility), [docs](https://docs.deno.com/deploy/api/runtime-node)) ([view preset source](./src/presets/deno.ts)).
+This preset can be used to extend `nodeless` to use Deno's Node.js API Compatibility ([docs](https://docs.deno.com/runtime/manual/node/compatibility), [docs](https://docs.deno.com/deploy/api/runtime-node)).
 
 ```js
 import { env, nodeless, deno } from "unenv";
@@ -68,7 +68,7 @@ const envConfig = env(nodeless, deno, {});
 
 ### Built-in Node.js modules
 
-`unenv` provides a replacement for all Node.js built-ins for cross-platform compatiblity.
+`unenv` provides a replacement for all Node.js built-ins for cross-platform compatibility.
 
 | Module                                                                      | Status     | Source                                                             |
 | --------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------ |
@@ -145,9 +145,9 @@ import MockProxy from "unenv/runtime/mock/proxy";
 console.log(MockProxy().foo.bar()[0]);
 ```
 
-Above package doesn't work outside of Node.js and neither we need any platform specific logic! When aliasing `os` to `mock/proxy-cjs`, it will be auto mocked using a [Proxy Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) which can be recursively traversed like an `Object`, called like a `Function`, Iterated like an `Array`, or instantiated like a `Class`.
+The above package doesn't work outside of Node.js and neither we need any platform-specific logic! When aliasing `os` to `mock/proxy-cjs`, it will be auto-mocked using a [Proxy Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) which can be recursively traversed like an `Object`, called like a `Function`, Iterated like an `Array`, or instantiated like a `Class`.
 
-We use this proxy for auto mocking unimplemented internals. Imagine a package does this:
+We use this proxy for auto-mocking unimplemented internals. Imagine a package does this:
 
 ```js
 const os = require("os");
@@ -157,11 +157,11 @@ if (os.platform() === "windows") {
 module.exports = () => "Hello world";
 ```
 
-By aliasing `os` to `unenv/runtime/mock/proxy-cjs`, code will be compatible with other platforms.
+By aliasing `os` to `unenv/runtime/mock/proxy-cjs`, the code will be compatible with other platforms.
 
 ## Other polyfills
 
-Please check [./src/runtime](./src/runtime) to discover other polyfills.
+To discover other polyfills, please check [./src/runtime](./src/runtime).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ pnpm add -D unenv
 Using `env` utility and built-in presets (and [nodeless](./src/presets/nodeless.ts)), `unenv` will provide an abstract configuration that can be used in building pipelines ([rollup.js](https://rollupjs.org), [webpack](https://webpack.js.org), etc.).
 
 ```js
-import { env, node, nodeless } from "unenv";
+import { env, node, deno, nodeless } from "unenv";
 
-const { alias, inject, polyfill, external } = env(...presets);
+const { alias, inject, polyfill, external } = env(nodeless, {});
 ```
 
 ## Presets
@@ -34,13 +34,31 @@ Suitable to convert universal libraries working in Node.js. ([preset](./src/pres
 - Add supports for global [`fetch` API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
 - Set Node.js built-ins as externals
 
+```js
+import { env, nodeless } from "unenv";
+
+const envConfig = env(node, {});
+```
+
 ### `nodeless`
 
 Using this preset, we can convert a code that is depending on Node.js to work anywhere else.
 
+```js
+import { env, nodeless } from "unenv";
+
+const envConfig = env(nodeless, {});
+```
+
 ### `deno`
 
-This preset extends `nodeless` but allows using Deno's Node API Compatibility ([docs](https://docs.deno.com/runtime/manual/node/compatibility) and [docs](https://docs.deno.com/deploy/api/runtime-node)) ([preset](./src/presets/deno.ts)).
+This preset can be used to extend `nodeless` to using Deno's Node API Compatibility ([docs](https://docs.deno.com/runtime/manual/node/compatibility) and [docs](https://docs.deno.com/deploy/api/runtime-node)) ([preset](./src/presets/deno.ts)).
+
+```js
+import { env, nodeless, deno } from "unenv";
+
+const envConfig = env(nodeless, deno, {});
+```
 
 ### Built-in Node.js modules
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ import { env, nodeless } from "unenv";
 const envConfig = env(node, {});
 ```
 
-([view `node` preset source](./src/presets/node.ts))
+[(view `node` preset source)](./src/presets/node.ts)
 
 ### `nodeless` preset
 
@@ -52,7 +52,7 @@ import { env, nodeless } from "unenv";
 const envConfig = env(nodeless, {});
 ```
 
-([view `nodeless` preset source](./src/presets/nodeless.ts))
+[(view `nodeless` preset source)](./src/presets/nodeless.ts)
 
 ### `deno` preset
 
@@ -64,7 +64,7 @@ import { env, nodeless, deno } from "unenv";
 const envConfig = env(nodeless, deno, {});
 ```
 
-([view `deno` preset source](./src/presets/deno.ts))
+[(view `deno` preset source)](./src/presets/deno.ts)
 
 ### Built-in Node.js modules
 

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ pnpm add -D unenv
 
 ## Usage
 
-Using `env` utility and built-in presets (and [nodeless](./src/presets/nodeless.ts)), `unenv` will provide an abstract configuration that can be used in building pipelines ([rollup.js](https://rollupjs.org), [webpack](https://webpack.js.org), etc.).
+Using `env` utility and built-in presets, `unenv` will provide an abstract configuration that can be used in building pipelines ([rollup.js](https://rollupjs.org), [webpack](https://webpack.js.org), etc.).
 
 ```js
-import { env, node, deno, nodeless } from "unenv";
+import { env } from "unenv";
 
-const { alias, inject, polyfill, external } = env(nodeless, {});
+const { alias, inject, polyfill, external } = env({}, {}, {});
 ```
 
-## Presets
+**Note:** You can provide as many presets as you want. unenv will merge them internally and the right most preset has higher periority.
 
-### `node`
+### `node` preset
 
 Suitable to convert universal libraries working in Node.js. ([preset](./src/presets/node.ts))
 
@@ -40,7 +40,7 @@ import { env, nodeless } from "unenv";
 const envConfig = env(node, {});
 ```
 
-### `nodeless`
+### `nodeless` preset
 
 Using this preset, we can convert a code that is depending on Node.js to work anywhere else.
 
@@ -50,7 +50,7 @@ import { env, nodeless } from "unenv";
 const envConfig = env(nodeless, {});
 ```
 
-### `deno`
+### `deno` preset
 
 This preset can be used to extend `nodeless` to using Deno's Node API Compatibility ([docs](https://docs.deno.com/runtime/manual/node/compatibility) and [docs](https://docs.deno.com/deploy/api/runtime-node)) ([preset](./src/presets/deno.ts)).
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "prepack": "unbuild",
     "release": "pnpm test && changelogen --release && pnpm publish && git push --follow-tags",
     "test": "pnpm lint && pnpm typecheck",
+    "test:deno": "NODE_NO_WARNINGS=1 pnpm jiti test/deno.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/src/presets/deno.ts
+++ b/src/presets/deno.ts
@@ -1,9 +1,8 @@
 import type { Preset } from "../types";
-import nodeless from "./nodeless";
 
 // https://docs.deno.com/runtime/manual/node/compatibility
 // https://docs.deno.com/deploy/api/runtime-node
-export const denoNodeCompatModules = [
+const denoNodeCompatModules = [
   "assert",
   "assert/strict",
   "async_hooks",
@@ -56,16 +55,11 @@ export const denoNodeCompatModules = [
 
 const denoPreset: Preset = {
   alias: {
-    ...nodeless.alias,
     ...Object.fromEntries(denoNodeCompatModules.map((p) => [p, `node:${p}`])),
     ...Object.fromEntries(
       denoNodeCompatModules.map((p) => [`node:${p}`, `node:${p}`]),
     ),
-  },
-  inject: {
-    ...nodeless.inject,
-  },
-  polyfill: [...(nodeless.polyfill as string[])],
+  }
 };
 
 export default denoPreset;

--- a/src/presets/deno.ts
+++ b/src/presets/deno.ts
@@ -1,0 +1,73 @@
+import nodeless from "./nodeless";
+import type { Preset } from "../types";
+
+// https://docs.deno.com/runtime/manual/node/compatibility
+// https://docs.deno.com/deploy/api/runtime-node
+export const denoNodeCompatModules = [
+  "assert",
+  "assert/strict",
+  "async_hooks",
+  "buffer",
+  "child_process",
+  "cluster",
+  "console",
+  "constants",
+  "crypto",
+  "dgram",
+  "diagnostics_channel",
+  "dns",
+  "dns/promises",
+  "domain",
+  "events",
+  "fs",
+  "fs/promises",
+  "http",
+  "http2",
+  "https",
+  "module",
+  "net",
+  "os",
+  "path",
+  "path/posix",
+  "path/win32",
+  "perf_hooks",
+  "process",
+  "punycode",
+  "querystring",
+  "readline",
+  "stream",
+  "stream/consumers",
+  "stream/promises",
+  "stream/web",
+  "string_decoder",
+  "sys",
+  "timers",
+  "timers/promises",
+  "tls",
+  "tty",
+  "url",
+  "util",
+  "util/types",
+  "v8",
+  "vm",
+  "worker_threads",
+  "zlib",
+];
+
+const denoPreset: Preset = {
+  alias: {
+    ...nodeless.alias,
+    ...Object.fromEntries(denoNodeCompatModules.map(p => [p, `node:${p}`])),
+    ...Object.fromEntries(denoNodeCompatModules.map(p => [`node:${p}`, `node:${p}`]))
+  },
+  inject: {
+    ...nodeless.inject
+  },
+  polyfill: [
+    ...nodeless.polyfill as string[]
+  ]
+}
+
+export default denoPreset;
+
+

--- a/src/presets/deno.ts
+++ b/src/presets/deno.ts
@@ -2,6 +2,7 @@ import type { Preset } from "../types";
 
 // https://docs.deno.com/runtime/manual/node/compatibility
 // https://docs.deno.com/deploy/api/runtime-node
+// Last checked: 2023-12-13
 const denoNodeCompatModules = [
   "assert",
   "assert/strict",
@@ -60,6 +61,17 @@ const denoPreset: Preset = {
       denoNodeCompatModules.map((p) => [`node:${p}`, `node:${p}`]),
     ),
   },
+  // Deno's listed globals manually tested against deno@1.38.5
+  // TODO: missing BroadcastChannel, PerformanceObserverEntryList, PerformanceResourceTiming
+  // TODO: global and process
+  inject: {
+    setImmediate: "node:timers",
+    clearImmediate: "node:timers",
+    Buffer: "node:buffer",
+    PerformanceObserver: "node:perf_hooks",
+  },
+  polyfill: ["unenv/runtime/polyfill/global"],
+  external: denoNodeCompatModules.map((p) => `node:${p}`),
 };
 
 export default denoPreset;

--- a/src/presets/deno.ts
+++ b/src/presets/deno.ts
@@ -59,7 +59,7 @@ const denoPreset: Preset = {
     ...Object.fromEntries(
       denoNodeCompatModules.map((p) => [`node:${p}`, `node:${p}`]),
     ),
-  }
+  },
 };
 
 export default denoPreset;

--- a/src/presets/deno.ts
+++ b/src/presets/deno.ts
@@ -1,5 +1,5 @@
-import nodeless from "./nodeless";
 import type { Preset } from "../types";
+import nodeless from "./nodeless";
 
 // https://docs.deno.com/runtime/manual/node/compatibility
 // https://docs.deno.com/deploy/api/runtime-node
@@ -57,17 +57,15 @@ export const denoNodeCompatModules = [
 const denoPreset: Preset = {
   alias: {
     ...nodeless.alias,
-    ...Object.fromEntries(denoNodeCompatModules.map(p => [p, `node:${p}`])),
-    ...Object.fromEntries(denoNodeCompatModules.map(p => [`node:${p}`, `node:${p}`]))
+    ...Object.fromEntries(denoNodeCompatModules.map((p) => [p, `node:${p}`])),
+    ...Object.fromEntries(
+      denoNodeCompatModules.map((p) => [`node:${p}`, `node:${p}`]),
+    ),
   },
   inject: {
-    ...nodeless.inject
+    ...nodeless.inject,
   },
-  polyfill: [
-    ...nodeless.polyfill as string[]
-  ]
-}
+  polyfill: [...(nodeless.polyfill as string[])],
+};
 
 export default denoPreset;
-
-

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,2 +1,3 @@
 export { default as node } from "./node";
 export { default as nodeless } from "./nodeless";
+export { default as deno } from "./deno";

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -1,0 +1,5 @@
+import { env, nodeless, deno } from "../src";
+
+const denoConfig = env(nodeless, deno);
+
+console.log(denoConfig);

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -1,5 +1,72 @@
+import { writeFileSync, mkdirSync, readFile, readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { createRequire } from "node:module";
+import consola from "consola";
+import { colors } from "consola/utils";
 import { env, nodeless, deno } from "../src";
 
 const denoConfig = env(nodeless, deno);
 
-console.log(denoConfig);
+const testCode = `
+const nodeImports = { ${Object.entries(denoConfig.alias)
+  .filter(([id]) => id.startsWith("node:"))
+  .map(([id, alias]) => {
+    if (!alias.startsWith("node:")) {
+      return `"${id}": "<unenv>",`;
+    }
+    return `"${id}": Object.keys(await import("${id}")),`;
+  })
+  .join("\n")}
+};
+
+const support = {
+  nodeImports
+}
+
+await Deno.writeFile(".tmp/deno-support.json", new TextEncoder().encode(JSON.stringify(support, null, 2)));
+`;
+
+mkdirSync(new URL(".tmp", import.meta.url), { recursive: true });
+
+writeFileSync(new URL(".tmp/deno-test.mjs", import.meta.url), testCode);
+
+execSync("deno run -A .tmp/deno-test.mjs", {
+  cwd: new URL(".", import.meta.url),
+  stdio: "inherit",
+});
+
+const { nodeImports } = JSON.parse(
+  readFileSync(new URL(".tmp/deno-support.json", import.meta.url), "utf8"),
+) as { nodeImports: Record<string, "<unenv>" | string[]> };
+
+const _require = createRequire(import.meta.url);
+
+const output: string[] = [];
+output.push("Feature | Status | Details");
+output.push("--- | --- | ---");
+
+for (const [name, denoExports] of Object.entries(nodeImports)) {
+  if (denoExports === "<unenv>") {
+    output.push(`${name} | ℹ️ | Using unenv`);
+    continue;
+  }
+  const nodeExports = Object.keys(_require(name));
+  const diffExports = diff(nodeExports, denoExports);
+  if (diffExports.length > 0) {
+    output.push(
+      `${name} | ⚠️ Partial support | Missing: ${
+        diffExports.length > 10
+          ? `${diffExports.length} exports`
+          : diffExports.map((i) => `\`${i}\``).join(", ")
+      }`,
+    );
+  } else {
+    output.push(`${name} | ✅ Full support | -`);
+  }
+}
+
+console.log(output.join("\n"));
+
+function diff(a: string[] = [], b: string[] = []) {
+  return a.filter((v) => !b.includes(v));
+}

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -1,8 +1,6 @@
 import { writeFileSync, mkdirSync, readFile, readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { createRequire } from "node:module";
-import consola from "consola";
-import { colors } from "consola/utils";
 import { env, nodeless, deno } from "../src";
 
 const denoConfig = env(nodeless, deno);
@@ -47,21 +45,21 @@ output.push("--- | --- | ---");
 
 for (const [name, denoExports] of Object.entries(nodeImports)) {
   if (denoExports === "<unenv>") {
-    output.push(`${name} | ℹ️ | Using unenv`);
+    output.push(`${name} | ℹ️ unenv | Using unenv`);
     continue;
   }
   const nodeExports = Object.keys(_require(name));
   const diffExports = diff(nodeExports, denoExports);
   if (diffExports.length > 0) {
     output.push(
-      `${name} | ⚠️ Partial support | Missing: ${
+      `${name} | ⚠️ partial | Missing: ${
         diffExports.length > 10
-          ? `${diffExports.length} exports`
+          ? `**${diffExports.length}** exports!!`
           : diffExports.map((i) => `\`${i}\``).join(", ")
       }`,
     );
   } else {
-    output.push(`${name} | ✅ Full support | -`);
+    output.push(`${name} | ✅ full | -`);
   }
 }
 


### PR DESCRIPTION
This PR adds a new `deno` preset suitable to extend `nodeless` with supported modules. 

**Note:** For ⚠️ _partial_ supported modules, using this preset means disabling unenv support for them!

Support status for Node v20.10.0 vs Deno v1.38.5


Feature | Status | Details
--- | --- | ---
node:inspector/promises | ℹ️ unenv | Using unenv
node:readline/promises | ℹ️ unenv | Using unenv
node:stream/consumers | ✅ full | -
node:stream/promises | ✅ full | -
node:timers/promises | ⚠️ partial | Missing: `scheduler`
node:assert/strict | ⚠️ partial | Missing: `CallTracker`
node:dns/promises | ⚠️ partial | Missing: `lookupService`, `getDefaultResultOrder`
node:fs/promises | ⚠️ partial | Missing: `cp`, `statfs`, `lchmod`, `lchown`, `lutimes`, `constants`
node:path/posix | ⚠️ partial | Missing: `win32`, `posix`, `_makeLong`
node:path/win32 | ⚠️ partial | Missing: `win32`, `posix`, `_makeLong`
node:stream/web | ⚠️ partial | Missing: `CompressionStream`, `DecompressionStream`
node:util/types | ⚠️ partial | Missing: `isExternal`
node:_stream_passthrough | ℹ️ unenv | Using unenv
node:diagnostics_channel | ⚠️ partial | Missing: `tracingChannel`
node:_stream_transform | ℹ️ unenv | Using unenv
node:_stream_readable | ℹ️ unenv | Using unenv
node:_stream_writable | ℹ️ unenv | Using unenv
node:_http_incoming | ℹ️ unenv | Using unenv
node:_http_outgoing | ℹ️ unenv | Using unenv
node:_stream_duplex | ℹ️ unenv | Using unenv
node:string_decoder | ✅ full | -
node:worker_threads | ✅ full | -
node:child_process | ⚠️ partial | Missing: `_forkChild`
node:_http_client | ℹ️ unenv | Using unenv
node:_http_common | ℹ️ unenv | Using unenv
node:_http_server | ℹ️ unenv | Using unenv
node:_stream_wrap | ℹ️ unenv | Using unenv
node:trace_events | ℹ️ unenv | Using unenv
node:_http_agent | ℹ️ unenv | Using unenv
node:_tls_common | ℹ️ unenv | Using unenv
node:async_hooks | ⚠️ partial | Missing: `triggerAsyncId`, `executionAsyncResource`, `asyncWrapProviders`
node:querystring | ✅ full | -
node:perf_hooks | ⚠️ partial | Missing: `Performance`, `PerformanceMark`, `PerformanceMeasure`, `PerformanceObserverEntryList`, `PerformanceResourceTiming`, `createHistogram`
node:_tls_wrap | ℹ️ unenv | Using unenv
node:constants | ⚠️ partial | Missing: **81** exports!!
node:inspector | ℹ️ unenv | Using unenv
node:punycode | ⚠️ partial | Missing: `version`
node:readline | ✅ full | -
node:cluster | ⚠️ partial | Missing: `_events`, `_eventsCount`, `_maxListeners`, `SCHED_NONE`, `SCHED_RR`, `disconnect`
node:console | ⚠️ partial | Missing: `context`, `createTask`
node:process | ⚠️ partial | Missing: **56** exports!!
node:assert | ⚠️ partial | Missing: `CallTracker`
node:buffer | ⚠️ partial | Missing: `transcode`, `isUtf8`, `isAscii`, `INSPECT_MAX_BYTES`, `resolveObjectURL`, `File`
node:crypto | ⚠️ partial | Missing: `Cipher`, `Decipher`, `subtle`, `getRandomValues`
node:domain | ⚠️ partial | Missing: `_stack`, `createDomain`, `active`
node:events | ⚠️ partial | Missing: `addAbortListener`, `getMaxListeners`, `usingDomains`, `captureRejections`, `EventEmitterAsyncResource`, `init`
node:module | ⚠️ partial | Missing: `_debug`, `isBuiltin`, `syncBuiltinESMExports`, `runMain`, `findSourceMap`, `register`, `SourceMap`
node:stream | ⚠️ partial | Missing: `isDestroyed`, `isDisturbed`, `isErrored`, `isReadable`, `isWritable`, `destroy`, `compose`, `setDefaultHighWaterMark`, `getDefaultHighWaterMark`, `promises`
node:timers | ⚠️ partial | Missing: `_unrefActive`, `active`, `unenroll`, `enroll`
node:dgram | ⚠️ partial | Missing: `_createSocketHandle`
node:http2 | ✅ full | -
node:https | ✅ full | -
node:http | ⚠️ partial | Missing: `_connectionListener`, `validateHeaderName`, `validateHeaderValue`, `setMaxIdleHTTPParsers`, `maxHeaderSize`
node:path | ⚠️ partial | Missing: `_makeLong`
node:repl | ℹ️ unenv | Using unenv
node:util | ⚠️ partial | Missing: `_errnoException`, `_exceptionWithHostPort`, `debug`, `getSystemErrorMap`, `transferableAbortSignal`, `transferableAbortController`, `aborted`, `parseArgs`, `MIMEType`, `MIMEParams`
node:wasi | ℹ️ unenv | Using unenv
node:zlib | ✅ full | -
node:dns | ⚠️ partial | Missing: `lookupService`, `getDefaultResultOrder`
node:net | ⚠️ partial | Missing: `_setSimultaneousAccepts`, `BlockList`, `SocketAddress`, `getDefaultAutoSelectFamily`, `setDefaultAutoSelectFamily`, `getDefaultAutoSelectFamilyAttemptTimeout`, `setDefaultAutoSelectFamilyAttemptTimeout`
node:sys | ⚠️ partial | Missing: `_errnoException`, `_exceptionWithHostPort`, `debug`, `getSystemErrorMap`, `transferableAbortSignal`, `transferableAbortController`, `aborted`, `parseArgs`, `MIMEType`, `MIMEParams`
node:tls | ⚠️ partial | Missing: `CLIENT_RENEG_LIMIT`, `CLIENT_RENEG_WINDOW`, `convertALPNProtocols`, `SecureContext`
node:tty | ✅ full | -
node:url | ✅ full | -
node:fs | ⚠️ partial | Missing: **20** exports!!
node:os | ⚠️ partial | Missing: `machine`
node:v8 | ⚠️ partial | M