### PR TITLE
feat: experimental vercel preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const envConfig = env(nodeless, deno, {});
 
 [(view source)](./src/presets/cloudflare.ts)
 
-This preset can be used to extend `nodeless` to use Cloudflare Worker's Node.js API Compatibility ([docs](https://developers.cloudflare.com/workers/runtime-apis/nodejs/)).
+This preset can be used to extend `nodeless` to use [Cloudflare Worker](https://workers.cloudflare.com/) Node.js API Compatibility ([docs](https://developers.cloudflare.com/workers/runtime-apis/nodejs/)).
 
 > [!WARNING]
 > This preset is **experimental** and behavior might change!
@@ -87,6 +87,19 @@ This preset can be used to extend `nodeless` to use Cloudflare Worker's Node.js 
 import { env, nodeless, cloudflare } from "unenv";
 
 const envConfig = env(nodeless, cloudflare, {});
+```
+
+### `vercel`
+
+This preset can be used to extend `nodeless` to use [Vercel Edge](https://vercel.com/docs/functions/edge-functions/edge-runtime) Node.js API Compatibility ([docs](https://vercel.com/docs/functions/edge-functions/edge-runtime#compatible-node.js-modules)).
+
+> [!WARNING]
+> This preset is **experimental** and behavior might change!
+
+```js
+import { env, nodeless, vercel } from "unenv";
+
+const envConfig = env(nodeless, vercel, {});
 ```
 
 ## Built-in Node.js modules

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "release": "pnpm test && changelogen --release && pnpm publish && git push --follow-tags",
     "test": "pnpm lint && pnpm typecheck",
     "test:deno": "NODE_NO_WARNINGS=1 pnpm jiti test/deno.ts",
-    "test:cf": "NODE_NO_WARNINGS=1 pnpm jiti test/cloudflare.ts",
+    "test:cf": "pnpm jiti test/cloudflare.ts",
+    "test:vc": "pnpm jiti test/vercel.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -46,6 +47,7 @@
   "devDependencies": {
     "@types/node": "^20.10.3",
     "changelogen": "^0.5.5",
+    "edge-runtime": "^2.5.7",
     "eslint": "^8.55.0",
     "eslint-config-unjs": "^0.2.1",
     "jiti": "^1.21.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "devDependencies": {
     "@types/node": "^20.10.3",
     "changelogen": "^0.5.5",
-    "edge-runtime": "^2.5.7",
     "eslint": "^8.55.0",
     "eslint-config-unjs": "^0.2.1",
     "jiti": "^1.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ devDependencies:
   changelogen:
     specifier: ^0.5.5
     version: 0.5.5
+  edge-runtime:
+    specifier: ^2.5.7
+    version: 2.5.7
   eslint:
     specifier: ^8.55.0
     version: 8.55.0
@@ -312,6 +315,28 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@edge-runtime/format@2.2.0:
+    resolution: {integrity: sha512-gPrS6AVw/qJJL0vcxMXv4kFXCU3ZTCD1uuJpwX15YxHV8BgU9OG5v9LrkkXcr96PBT/9epypfNJMhlWADuEziw==}
+    engines: {node: '>=16'}
+    dev: true
+
+  /@edge-runtime/ponyfill@2.4.1:
+    resolution: {integrity: sha512-ZbR/EViY3gg2rmEAQTKPa6mXl4aR1/+cFcQe4r1segCjEbTAxT6PWu40odbu/KlZKSysEb2O/BWIC2lJgSJOMQ==}
+    engines: {node: '>=16'}
+    dev: true
+
+  /@edge-runtime/primitives@4.0.5:
+    resolution: {integrity: sha512-t7QiN5d/KpXgCvIfSt6Nm9Hj3WVdNgc5CpOD73jasY+9EvTI7Ngdj5cXvjcHrPcmYWJZMySPgeEeoL/1N/Llag==}
+    engines: {node: '>=16'}
+    dev: true
+
+  /@edge-runtime/vm@3.1.7:
+    resolution: {integrity: sha512-hUMFbDQ/nZN+1TLMi6iMO1QFz9RSV8yGG8S42WFPFma1d7VSNE0eMdJUmwjmtav22/iQkzHMmu6oTSfAvRGS8g==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@edge-runtime/primitives': 4.0.5
+    dev: true
 
   /@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.17.19):
     resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
@@ -1248,6 +1273,11 @@ packages:
       printable-characters: 1.0.42
     dev: true
 
+  /async-listen@3.0.1:
+    resolution: {integrity: sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA==}
+    engines: {node: '>= 14'}
+    dev: true
+
   /autoprefixer@10.4.16(postcss@8.4.31):
     resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1540,6 +1570,11 @@ packages:
     resolution: {integrity: sha512-t5yxPyI8h8KPvRwrS/sRrfIpT2gJbmBAY0TFokyUBy3PM44RuFRpZwHdACz+GTSPLRLo3s4qsscOMLjHiXBwzw==}
     dev: true
 
+  /convert-hrtime@3.0.0:
+    resolution: {integrity: sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==}
+    engines: {node: '>=8'}
+    dev: true
+
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
     dev: true
@@ -1804,6 +1839,22 @@ packages:
   /dotenv@16.3.1:
     resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
     engines: {node: '>=12'}
+    dev: true
+
+  /edge-runtime@2.5.7:
+    resolution: {integrity: sha512-gA4qSVP0sNwJlkdQ2nahDPASlSl8twUd17o+JolPa1EtXpLTGzIpOETvodgJwXIxa+zaD8bnAXCdsWrx2PhlVQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      '@edge-runtime/format': 2.2.0
+      '@edge-runtime/ponyfill': 2.4.1
+      '@edge-runtime/vm': 3.1.7
+      async-listen: 3.0.1
+      mri: 1.2.0
+      picocolors: 1.0.0
+      pretty-ms: 7.0.1
+      signal-exit: 4.0.2
+      time-span: 4.0.0
     dev: true
 
   /electron-to-chromium@1.4.590:
@@ -3528,6 +3579,11 @@ packages:
       lines-and-columns: 1.2.4
     dev: true
 
+  /parse-ms@2.1.0:
+    resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
+    engines: {node: '>=6'}
+    dev: true
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3919,6 +3975,13 @@ packages:
     engines: {node: ^14.13.1 || >=16.0.0}
     dev: true
 
+  /pretty-ms@7.0.1:
+    resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      parse-ms: 2.1.0
+    dev: true
+
   /printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
     dev: true
@@ -4180,6 +4243,11 @@ packages:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
 
+  /signal-exit@4.0.2:
+    resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
+    engines: {node: '>=14'}
+    dev: true
+
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4378,6 +4446,13 @@ packages:
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+    dev: true
+
+  /time-span@4.0.0:
+    resolution: {integrity: sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==}
+    engines: {node: '>=10'}
+    dependencies:
+      convert-hrtime: 3.0.0
     dev: true
 
   /titleize@3.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,9 +28,6 @@ devDependencies:
   changelogen:
     specifier: ^0.5.5
     version: 0.5.5
-  edge-runtime:
-    specifier: ^2.5.7
-    version: 2.5.7
   eslint:
     specifier: ^8.55.0
     version: 8.55.0
@@ -315,28 +312,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /@edge-runtime/format@2.2.0:
-    resolution: {integrity: sha512-gPrS6AVw/qJJL0vcxMXv4kFXCU3ZTCD1uuJpwX15YxHV8BgU9OG5v9LrkkXcr96PBT/9epypfNJMhlWADuEziw==}
-    engines: {node: '>=16'}
-    dev: true
-
-  /@edge-runtime/ponyfill@2.4.1:
-    resolution: {integrity: sha512-ZbR/EViY3gg2rmEAQTKPa6mXl4aR1/+cFcQe4r1segCjEbTAxT6PWu40odbu/KlZKSysEb2O/BWIC2lJgSJOMQ==}
-    engines: {node: '>=16'}
-    dev: true
-
-  /@edge-runtime/primitives@4.0.5:
-    resolution: {integrity: sha512-t7QiN5d/KpXgCvIfSt6Nm9Hj3WVdNgc5CpOD73jasY+9EvTI7Ngdj5cXvjcHrPcmYWJZMySPgeEeoL/1N/Llag==}
-    engines: {node: '>=16'}
-    dev: true
-
-  /@edge-runtime/vm@3.1.7:
-    resolution: {integrity: sha512-hUMFbDQ/nZN+1TLMi6iMO1QFz9RSV8yGG8S42WFPFma1d7VSNE0eMdJUmwjmtav22/iQkzHMmu6oTSfAvRGS8g==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@edge-runtime/primitives': 4.0.5
-    dev: true
 
   /@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.17.19):
     resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
@@ -1273,11 +1248,6 @@ packages:
       printable-characters: 1.0.42
     dev: true
 
-  /async-listen@3.0.1:
-    resolution: {integrity: sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA==}
-    engines: {node: '>= 14'}
-    dev: true
-
   /autoprefixer@10.4.16(postcss@8.4.31):
     resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1570,11 +1540,6 @@ packages:
     resolution: {integrity: sha512-t5yxPyI8h8KPvRwrS/sRrfIpT2gJbmBAY0TFokyUBy3PM44RuFRpZwHdACz+GTSPLRLo3s4qsscOMLjHiXBwzw==}
     dev: true
 
-  /convert-hrtime@3.0.0:
-    resolution: {integrity: sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==}
-    engines: {node: '>=8'}
-    dev: true
-
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
     dev: true
@@ -1839,22 +1804,6 @@ packages:
   /dotenv@16.3.1:
     resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
     engines: {node: '>=12'}
-    dev: true
-
-  /edge-runtime@2.5.7:
-    resolution: {integrity: sha512-gA4qSVP0sNwJlkdQ2nahDPASlSl8twUd17o+JolPa1EtXpLTGzIpOETvodgJwXIxa+zaD8bnAXCdsWrx2PhlVQ==}
-    engines: {node: '>=16'}
-    hasBin: true
-    dependencies:
-      '@edge-runtime/format': 2.2.0
-      '@edge-runtime/ponyfill': 2.4.1
-      '@edge-runtime/vm': 3.1.7
-      async-listen: 3.0.1
-      mri: 1.2.0
-      picocolors: 1.0.0
-      pretty-ms: 7.0.1
-      signal-exit: 4.0.2
-      time-span: 4.0.0
     dev: true
 
   /electron-to-chromium@1.4.590:
@@ -3579,11 +3528,6 @@ packages:
       lines-and-columns: 1.2.4
     dev: true
 
-  /parse-ms@2.1.0:
-    resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
-    engines: {node: '>=6'}
-    dev: true
-
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3975,13 +3919,6 @@ packages:
     engines: {node: ^14.13.1 || >=16.0.0}
     dev: true
 
-  /pretty-ms@7.0.1:
-    resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
-    engines: {node: '>=10'}
-    dependencies:
-      parse-ms: 2.1.0
-    dev: true
-
   /printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
     dev: true
@@ -4243,11 +4180,6 @@ packages:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
 
-  /signal-exit@4.0.2:
-    resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
-    engines: {node: '>=14'}
-    dev: true
-
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4446,13 +4378,6 @@ packages:
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
-    dev: true
-
-  /time-span@4.0.0:
-    resolution: {integrity: sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==}
-    engines: {node: '>=10'}
-    dependencies:
-      convert-hrtime: 3.0.0
     dev: true
 
   /titleize@3.0.0:

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -2,3 +2,4 @@ export { default as node } from "./node";
 export { default as nodeless } from "./nodeless";
 export { default as deno } from "./deno";
 export { default as cloudflare } from "./cloudflare";
+export { default as vercel } from "./vercel";

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -1,12 +1,12 @@
 import type { Preset } from "../types";
 
-// https://vercel.com/docs/functions/edge-functions/edge-runtime
+// https://vercel.com/docs/functions/edge-functions/edge-runtime#compatible-node.js-modules
 // Last checked: 2023-12-14
 const vercelNodeCompatModules = [
   "async_hooks",
   "events",
   "buffer",
-  "asset",
+  "assert",
   "util",
 ];
 

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -1,0 +1,25 @@
+import type { Preset } from "../types";
+
+// https://vercel.com/docs/functions/edge-functions/edge-runtime
+// Last checked: 2023-12-14
+const vercelNodeCompatModules = [
+  "async_hooks",
+  "events",
+  "buffer",
+  "asset",
+  "util",
+];
+
+const vercelPreset: Preset = {
+  alias: {
+    ...Object.fromEntries(vercelNodeCompatModules.map((p) => [p, `node:${p}`])),
+    ...Object.fromEntries(
+      vercelNodeCompatModules.map((p) => [`node:${p}`, `node:${p}`]),
+    ),
+  },
+  inject: {},
+  polyfill: [],
+  external: vercelNodeCompatModules.map((p) => `node:${p}`),
+};
+
+export default vercelPreset;

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -12,9 +12,9 @@ async function main() {
   const _env = env(nodeless, deno);
 
   const testCode = `
-  ${genRuntimeTest(_env)}
-  const result = await testRuntime();
-  await Deno.writeFile("deno.json", new TextEncoder().encode(JSON.stringify(result, null, 2)));
+${genRuntimeTest(_env)}
+const result = await testRuntime();
+await Deno.writeFile("deno.json", new TextEncoder().encode(JSON.stringify(result, null, 2)));
   `;
 
   mkdirSync(resolveTmp(), { recursive: true });

--- a/test/vercel.ts
+++ b/test/vercel.ts
@@ -1,0 +1,85 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { env, nodeless, vercel } from "../src";
+import { genRuntimeTest, resolveTmp } from "./_utils";
+
+async function main() {
+  const _env = env(nodeless, vercel);
+
+  const outDir = "vercel/vercel_out";
+  const funcDir = `${outDir}/output/functions/__test.func`;
+
+  mkdirSync(resolveTmp(funcDir), { recursive: true });
+
+  const testCode = `
+${genRuntimeTest(_env)}
+export default async function handleEvent(request, event) {
+  const url = new URL(request.url);
+  const result = await testRuntime();
+  return new Response(JSON.stringify(result, null, 2), {
+    headers: {
+      "content-type": "application/json; charset=UTF-8",
+    },
+  });
+}
+  `;
+
+  writeFileSync(resolveTmp(`${funcDir}/index.mjs`), testCode);
+
+  writeFileSync(
+    resolveTmp(`${funcDir}/.vc-config.json`),
+    JSON.stringify(
+      {
+        runtime: "edge",
+        entrypoint: "index.mjs",
+      },
+      null,
+      2,
+    ),
+  );
+
+  writeFileSync(
+    resolveTmp(`${outDir}/config.json`),
+    JSON.stringify(
+      {
+        version: 3,
+        overrides: {},
+        routes: [
+          {
+            src: "/(.*)",
+            dest: "/__test",
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  writeFileSync(
+    resolveTmp(`vercel/package.json`),
+    JSON.stringify(
+      {
+        private: true,
+        scripts: {
+          build: "cp -vr vercel_out/* .vercel",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  // mkdirSync(resolveTmp(`${outDir}/static`), { recursive: true });
+  // writeFileSync(resolveTmp(`${outDir}/static/test.txt`), "hello world");
+
+  await execSync(`bunx vercel`, {
+    cwd: resolveTmp("vercel"),
+    stdio: "inherit",
+  });
+
+  // analyzeRuntimeTestResult(result);
+}
+
+// eslint-disable-next-line unicorn/prefer-top-level-await
+main();


### PR DESCRIPTION
Add support for vercel-edge node.js compatibility support (similar to #155, #156)

comparing https://unenv.vercel.dev against node 20.10.0 (local `pnpm test:vc`)

Feature | Status | Details
--- | --- | ---
node:inspector/promises | ℹ️ unenv | Using unenv
node:readline/promises | ℹ️ unenv | Using unenv
node:stream/consumers | ℹ️ unenv | Using unenv
node:stream/promises | ℹ️ unenv | Using unenv
node:timers/promises | ℹ️ unenv | Using unenv
node:assert/strict | ℹ️ unenv | Using unenv
node:dns/promises | ℹ️ unenv | Using unenv
node:fs/promises | ℹ️ unenv | Using unenv
node:path/posix | ℹ️ unenv | Using unenv
node:path/win32 | ℹ️ unenv | Using unenv
node:stream/web | ℹ️ unenv | Using unenv
node:util/types | ℹ️ unenv | Using unenv
node:_stream_passthrough | ℹ️ unenv | Using unenv
node:diagnostics_channel | ℹ️ unenv | Using unenv
node:_stream_transform | ℹ️ unenv | Using unenv
node:_stream_readable | ℹ️ unenv | Using unenv
node:_stream_writable | ℹ️ unenv | Using unenv
node:_http_incoming | ℹ️ unenv | Using unenv
node:_http_outgoing | ℹ️ unenv | Using unenv
node:_stream_duplex | ℹ️ unenv | Using unenv
node:string_decoder | ℹ️ unenv | Using unenv
node:worker_threads | ℹ️ unenv | Using unenv
node:child_process | ℹ️ unenv | Using unenv
node:_http_client | ℹ️ unenv | Using unenv
node:_http_common | ℹ️ unenv | Using unenv
node:_http_server | ℹ️ unenv | Using unenv
node:_stream_wrap | ℹ️ unenv | Using unenv
node:trace_events | ℹ️ unenv | Using unenv
node:_http_agent | ℹ️ unenv | Using unenv
node:_tls_common | ℹ️ unenv | Using unenv
node:async_hooks | ⚠️ partial | Missing: `createHook`, `executionAsyncId`, `triggerAsyncId`, `executionAsyncResource`, `asyncWrapProviders`
node:querystring | ℹ️ unenv | Using unenv
node:perf_hooks | ℹ️ unenv | Using unenv
node:_tls_wrap | ℹ️ unenv | Using unenv
node:constants | ℹ️ unenv | Using unenv
node:inspector | ℹ️ unenv | Using unenv
node:punycode | ℹ️ unenv | Using unenv
node:readline | ℹ️ unenv | Using unenv
node:cluster | ℹ️ unenv | Using unenv
node:console | ℹ️ unenv | Using unenv
node:process | ℹ️ unenv | Using unenv
node:assert | ⚠️ partial | Missing: `CallTracker`
node:buffer | ⚠️ partial | Missing: `transcode`, `isUtf8`, `isAscii`, `btoa`, `atob`, `INSPECT_MAX_BYTES`, `Blob`, `resolveObjectURL`, `File`
node:crypto | ℹ️ unenv | Using unenv
node:domain | ℹ️ unenv | Using unenv
node:events | ⚠️ partial | Missing: `addAbortListener`, `getMaxListeners`, `usingDomains`, `captureRejections`, `init`
node:module | ℹ️ unenv | Using unenv
node:stream | ℹ️ unenv | Using unenv
node:timers | ℹ️ unenv | Using unenv
node:dgram | ℹ️ unenv | Using unenv
node:http2 | ℹ️ unenv | Using unenv
node:https | ℹ️ unenv | Using unenv
node:http | ℹ️ unenv | Using unenv
node:path | ℹ️ unenv | Using unenv
node:repl | ℹ️ unenv | Using unenv
node:util | ⚠️ partial | Missing: **31** exports!!
node:wasi | ℹ️ unenv | Using unenv
node:zlib | ℹ️ unenv | Using unenv
node:dns | ℹ️ unenv | Using unenv
node:net | ℹ️ unenv | Using unenv
node:sys | ℹ️ unenv | Using unenv
node:tls | ℹ️ unenv | Using unenv
node:tty | ℹ️ unenv | Using unenv
node:url | ℹ️ unenv | Using unenv
node:fs | ℹ️ unenv | Using unenv
node:os | ℹ️ unenv | Using unenv
node:v8 | ℹ️ unenv | Using unenv
node:vm | ℹ️ unenv | Using unenv