### PR TITLE
Add missing kOutHeaders property

### DIFF
--- a/src/runtime/node/http/_response.ts
+++ b/src/runtime/node/http/_response.ts
@@ -25,6 +25,7 @@ export class ServerResponse extends Writable implements http.ServerResponse {
   req: http.IncomingMessage;
 
   _headers: Record<string, number | string | string[] | undefined> = {};
+  kOutHeaders: Record<string, [string, string]> | null = null;
 
   constructor(req: http.IncomingMessage) {
     super();


### PR DESCRIPTION
The absence of this property caused Node's OutgoingMessage.prototype.setHeader function to fail as it checks for null but not for falsey or undefined.

When setHeader fails with unenv then nuxt can have problems properly rendering error pages for API routes/middleware.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The current re-implementation of `ServerResponse` is missing the property [`kOutHeaders`](https://github.com/nodejs/node/blob/main/lib/_http_outgoing.js#L152C8-L152C19). The absence of this property means that it's `undefined` but Node tests using `=== null` to check if the value needs to be initialized (see https://github.com/nodejs/node/blob/main/lib/_http_outgoing.js#L709).

Due to this when a Nuxt server route has an error it can fail to render since Nuxt will use [Nitro's `localFetch`](https://github.com/nuxt/nuxt/blob/6b504258bb2aafbd5eb54b3ab43b2749fade235a/packages/nuxt/src/core/runtime/nitro/error.ts#L57) which in turn uses [unenv's `createFetch`](https://github.com/unjs/nitro/blob/e9975ac36914f582d7c7b724945e0abdd398291a/src/runtime/app.ts#L16-L20) which in turn uses [unenv's `ServerResponse`](https://github.com/unjs/unenv/blob/5d5a7ba295c3c5fad9439b8ba834e1a4abf1280f/src/runtime/fetch/call.ts#L2). 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
