### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Suitable to convert universal libraries working in Node.js.
 - Set Node.js built-ins as externals
 
 ```js
-import { env, nodeless } from "unenv";
+import { env, node } from "unenv";
 
 const envConfig = env(node, {});
 ```


### PR DESCRIPTION
fix: typo in documentation: the example for the `node` preset imports `nodeless`.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
