### PR TITLE
fix(node:stream/web): add missing `DecompressionStream`

### DIFF
--- a/src/runtime/node/stream/web/index.ts
+++ b/src/runtime/node/stream/web/index.ts
@@ -1,4 +1,4 @@
-import type * as stramWeb from "node:stream/web";
+import type * as streamWeb from "node:stream/web";
 import { notImplemented } from "../../../_internal/utils";
 
 export const ReadableStream =
@@ -48,7 +48,7 @@ export const TextDecoderStream =
   notImplemented("stream.web.TextDecoderStream");
 
 // @ts-ignore
-export default <typeof stramWeb>{
+export default <typeof streamWeb>{
   ReadableStream,
   ReadableStreamDefaultReader,
   ReadableStreamBYOBReader,

--- a/src/runtime/node/stream/web/index.ts
+++ b/src/runtime/node/stream/web/index.ts
@@ -46,6 +46,9 @@ export const TextEncoderStream =
 export const TextDecoderStream =
   globalThis.TextDecoderStream ||
   notImplemented("stream.web.TextDecoderStream");
+export const DecompressionStream =
+  globalThis.DecompressionStream ||
+  notImplemented("stream.web.DecompressionStream");
 
 // @ts-ignore
 export default <typeof streamWeb>{
@@ -64,4 +67,5 @@ export default <typeof streamWeb>{
   CountQueuingStrategy,
   TextEncoderStream,
   TextDecoderStream,
+  DecompressionStream,
 };


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added the missing https://nodejs.org/api/webstreams.html#class-decompressionstream API to node:stream/web

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
