### PR TITLE
fix(cloudflare): make sure not fallback to `globalThis` for env

### DIFF
--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -35,7 +35,7 @@ const cloudflarePreset: Preset = {
     ),
   },
   inject: {},
-  polyfill: [],
+  polyfill: ["unenv/runtime/polyfill/cloudflare"],
   external: cloudflareNodeCompatModules.map((p) => `node:${p}`),
 };
 

--- a/src/runtime/polyfill/cloudflare.ts
+++ b/src/runtime/polyfill/cloudflare.ts
@@ -1,1 +1,2 @@
+// Make sure env polyfill won't fallback to legacy `globalThis` used for service-worker format
 (globalThis as any).__env__ = {};

--- a/src/runtime/polyfill/cloudflare.ts
+++ b/src/runtime/polyfill/cloudflare.ts
@@ -1,6 +1,1 @@
-type GlobalThis = typeof globalThis;
-interface GlobalThisPlusEnv extends GlobalThis {
-  __env__: typeof process.env;
-}
-
-(globalThis as GlobalThisPlusEnv).__env__ = {};
+(globalThis as any).__env__ = {};

--- a/src/runtime/polyfill/cloudflare.ts
+++ b/src/runtime/polyfill/cloudflare.ts
@@ -1,4 +1,6 @@
-import { nextTick } from "node:process";
-import { process as _process } from "../node/process/_process";
+type GlobalThis = typeof globalThis;
+interface GlobalThisPlusEnv extends GlobalThis {
+  __env__: typeof process.env;
+}
 
-Object.assign(_process, { nextTick });
+(globalThis as GlobalThisPlusEnv).__env__ = {};

--- a/src/runtime/polyfill/cloudflare.ts
+++ b/src/runtime/polyfill/cloudflare.ts
@@ -1,0 +1,4 @@
+import { nextTick } from "node:process";
+import { process as _process } from "../node/process/_process";
+
+Object.assign(_process, { nextTick });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Adds a polyfill for `process` to the Cloudflare preset which combines the [node polyfill](https://github.com/unjs/unenv/blob/main/src/runtime/node/process/_process.ts) with the [workerd polyfill](https://github.com/cloudflare/workerd/blob/main/src/node/internal/process.ts) implementation. We'd specifically like to retain the polyfilled `nextTick` from workerd which uses `queueMicrotask`, but benefit from all the other global `process` polyfills provided by unenv.

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
