### PR TITLE
feat(node:process): prefer `queueMicrotask` for `process.nextTick` polyfill

### DIFF
--- a/src/runtime/node/process/_process.ts
+++ b/src/runtime/node/process/_process.ts
@@ -135,7 +135,7 @@ function drainQueue() {
 }
 
 process.nextTick = function (fun) {
-  // https://github.com/cloudflare/workerd/blob/main/src/node/internal/process.ts
+  // https://nodejs.org/api/process.html#when-to-use-queuemicrotask-vs-processnexttick
   if (typeof queueMicrotask === "function") {
     queueMicrotask(() => { cb(...args); });
     return

--- a/src/runtime/node/process/_process.ts
+++ b/src/runtime/node/process/_process.ts
@@ -135,6 +135,11 @@ function drainQueue() {
 }
 
 process.nextTick = function (fun) {
+  // https://github.com/cloudflare/workerd/blob/main/src/node/internal/process.ts
+  if (typeof queueMicrotask === "function") {
+    queueMicrotask(() => { cb(...args); });
+    return
+  }
   const args = Array.from({ length: arguments.length - 1 });
   if (arguments.length > 1) {
     for (let i = 1; i < arguments.length; i++) {

--- a/src/runtime/node/process/_process.ts
+++ b/src/runtime/node/process/_process.ts
@@ -137,8 +137,10 @@ function drainQueue() {
 process.nextTick = function (fun) {
   // https://nodejs.org/api/process.html#when-to-use-queuemicrotask-vs-processnexttick
   if (typeof queueMicrotask === "function") {
-    queueMicrotask(() => { cb(...args); });
-    return
+    queueMicrotask(() => {
+      cb(...args);
+    });
+    return;
   }
   const args = Array.from({ length: arguments.length - 1 });
   if (arguments.length > 1) {


### PR DESCRIPTION
Idea from #183 use [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask) for [approximate `process.nextTick()`](https://nodejs.org/api/process.html#when-to-use-queuemicrotask-vs-processnexttick) in Node.js when available.