### PR TITLE
fix(node): rewrite the process.env polyfill

### DIFF
--- a/src/runtime/node/process/_process.ts
+++ b/src/runtime/node/process/_process.ts
@@ -167,34 +167,14 @@ Item.prototype.run = function () {
 };
 process.title = "unenv";
 
-const _envShim = Object.create(null);
-const _processEnv = globalThis.process?.env;
-const _getEnv = (useShim: boolean) =>
-  _processEnv || globalThis.__env__ || (useShim ? _envShim : globalThis);
+process.env = 
+  // preserve process.env if it exists
+  globalThis.process?.env ||
+  // use global __env__ if exists, this is used by nitro to inject env vars from build
+  globalThis.__env__ ||
+  // fall back on an empty object
+  Object.create(null);
 
-process.env = new Proxy(_envShim, {
-  get(_, prop) {
-    const env = _getEnv();
-    return env[prop] ?? _envShim[prop];
-  },
-  has(_, prop) {
-    const env = _getEnv();
-    return prop in env || prop in _envShim;
-  },
-  set(_, prop, value) {
-    const env = _getEnv(true);
-    env[prop] = value;
-    return true;
-  },
-  deleteProperty(_, prop) {
-    const env = _getEnv(true);
-    delete env[prop];
-  },
-  ownKeys() {
-    const env = _getEnv();
-    return Object.keys(env);
-  },
-});
 
 process.argv = [];
 // @ts-ignore

--- a/src/runtime/node/process/_process.ts
+++ b/src/runtime/node/process/_process.ts
@@ -167,14 +167,13 @@ Item.prototype.run = function () {
 };
 process.title = "unenv";
 
-process.env = 
+process.env =
   // preserve process.env if it exists
   globalThis.process?.env ||
   // use global __env__ if exists, this is used by nitro to inject env vars from build
   globalThis.__env__ ||
   // fall back on an empty object
   Object.create(null);
-
 
 process.argv = [];
 // @ts-ignore


### PR DESCRIPTION

### 🔗 Linked issue

https://github.com/unjs/unenv/pull/183

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The previous polyfill was unnecessarily complicated and hard to understand. Additionally it also used fallback on globalThis to read and write env variables, which in the past was used to read env variables in Cloudflare Workers in the case where workers were using the legacy service worker format. This style of workers is not actively used any more so this fallback is not needed, and in fact is undesirable as we never want to accidentaly write this globalThis.foo as a result of an assignment to process.env.foo.

The nitro utilized globalThis.__env__ fallback is preserved as to no break nitro users.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
