### PR TITLE
feat(node:dns): polyfill `node:dns` module

### DIFF
--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -15,6 +15,7 @@ const nodeless: Preset & { alias: Map<string, string> } = {
         "console",
         "crypto",
         "dns",
+        "dns/promises",
         "events",
         "fs",
         "fs/promises",

--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -14,6 +14,7 @@ const nodeless: Preset & { alias: Map<string, string> } = {
         "buffer",
         "console",
         "crypto",
+        "dns",
         "events",
         "fs",
         "fs/promises",

--- a/src/runtime/_internal/utils.ts
+++ b/src/runtime/_internal/utils.ts
@@ -36,6 +36,19 @@ export function notImplemented<Fn extends (...args: any) => any>(
   return Object.assign(fn, { __unenv__: true }) as unknown as Fn;
 }
 
+export interface Promisifiable {
+  (): any;
+  native: Promisifiable;
+  __promisify__: () => Promise<any>;
+}
+
+export function notImplementedAsync(name: string): Promisifiable {
+  const fn = notImplemented(name) as any;
+  fn.__promisify__ = () => notImplemented(name + ".__promisify__");
+  fn.native = fn;
+  return fn;
+}
+
 export function notImplementedClass<T = unknown>(name: string): T {
   return class {
     readonly __unenv__ = true;

--- a/src/runtime/node/dns/constants.ts
+++ b/src/runtime/node/dns/constants.ts
@@ -1,0 +1,30 @@
+import type dns from "node:dns";
+
+export const ADDRCONFIG: typeof dns.ADDRCONFIG = 0;
+export const ADDRGETNETWORKPARAMS: typeof dns.ADDRGETNETWORKPARAMS =
+  "ADDRGETNETWORKPARAMS";
+export const ALL: typeof dns.ALL = 0;
+export const BADFAMILY: typeof dns.BADFAMILY = "BADFAMILY";
+export const BADFLAGS: typeof dns.BADFLAGS = "BADFLAGS";
+export const BADHINTS: typeof dns.BADHINTS = "BADHINTS";
+export const BADNAME: typeof dns.BADNAME = "BADNAME";
+export const BADQUERY: typeof dns.BADQUERY = "BADQUERY";
+export const BADRESP: typeof dns.BADRESP = "BADRESP";
+export const BADSTR: typeof dns.BADSTR = "BADSTR";
+export const CANCELLED: typeof dns.CANCELLED = "CANCELLED";
+export const CONNREFUSED: typeof dns.CONNREFUSED = "TIMEOUT";
+export const DESTRUCTION: typeof dns.DESTRUCTION = "DESTRUCTION";
+export const EOF: typeof dns.EOF = "EOF";
+export const FILE: typeof dns.FILE = "FILE";
+export const FORMERR: typeof dns.FORMERR = "FORMERR";
+export const LOADIPHLPAPI: typeof dns.LOADIPHLPAPI = "LOADIPHLPAPI";
+export const NODATA: typeof dns.NODATA = "NODATA";
+export const NOMEM: typeof dns.NOMEM = "NOMEM";
+export const NONAME: typeof dns.NONAME = "NONAME";
+export const NOTFOUND: typeof dns.NOTFOUND = "NOTFOUND";
+export const NOTIMP: typeof dns.NOTIMP = "NOTIMP";
+export const NOTINITIALIZED: typeof dns.NOTINITIALIZED = "NOTINITIALIZED";
+export const REFUSED: typeof dns.REFUSED = "REFUSED";
+export const SERVFAIL: typeof dns.SERVFAIL = "SERVFAIL";
+export const TIMEOUT: typeof dns.TIMEOUT = "TIMEOUT";
+export const V4MAPPED: typeof dns.V4MAPPED = 2048;

--- a/src/runtime/node/dns/index.ts
+++ b/src/runtime/node/dns/index.ts
@@ -1,0 +1,75 @@
+import noop from "../../mock/noop";
+import mock from "../../mock/proxy";
+import {
+  notImplemented,
+  notImplementedAsync,
+} from "src/runtime/_internal/utils";
+import type dns from "node:dns";
+import * as constants from "./constants";
+export * from "./constants";
+
+export const Resolver: typeof dns.Resolver =
+  mock.__createMock__("dns.Resolver");
+export const getDefaultResultOrder: typeof dns.getDefaultResultOrder = () =>
+  "verbatim";
+export const getServers: typeof dns.getServers = () => [];
+export const lookup: typeof dns.lookup = notImplementedAsync("dns.lookup");
+export const lookupService: typeof dns.lookupService =
+  notImplementedAsync("dns.lookupService");
+export const promises: typeof dns.promises =
+  mock.__createMock__("dns.promises");
+export const resolve: typeof dns.resolve = notImplementedAsync("dns.resolve");
+export const resolve4: typeof dns.resolve4 =
+  notImplementedAsync("dns.resolve4");
+export const resolve6: typeof dns.resolve6 =
+  notImplementedAsync("dns.resolve6");
+export const resolveAny: typeof dns.resolveAny =
+  notImplementedAsync("dns.resolveAny");
+export const resolveCaa: typeof dns.resolveCaa =
+  notImplementedAsync("dns.resolveCaa");
+export const resolveCname: typeof dns.resolveCname =
+  notImplementedAsync("dns.resolveCname");
+export const resolveMx: typeof dns.resolveMx =
+  notImplementedAsync("dns.resolveMx");
+export const resolveNaptr: typeof dns.resolveNaptr =
+  notImplementedAsync("dns.resolveNaptr");
+export const resolveNs: typeof dns.resolveNs =
+  notImplementedAsync("dns.resolveNs");
+export const resolvePtr: typeof dns.resolvePtr =
+  notImplementedAsync("dns.resolvePtr");
+export const resolveSoa: typeof dns.resolveSoa =
+  notImplementedAsync("dns.resolveSoa");
+export const resolveSrv: typeof dns.resolveSrv =
+  notImplementedAsync("dns.resolveSrv");
+export const resolveTxt: typeof dns.resolveTxt =
+  notImplementedAsync("dns.resolveTxt");
+
+export const reverse: typeof dns.reverse = notImplemented("dns.reverse");
+export const setDefaultResultOrder: typeof dns.setDefaultResultOrder = noop;
+export const setServers: typeof dns.setServers = noop;
+
+export default <typeof dns>{
+  ...constants,
+  Resolver,
+  getDefaultResultOrder,
+  getServers,
+  lookup,
+  lookupService,
+  promises,
+  resolve,
+  resolve4,
+  resolve6,
+  resolveAny,
+  resolveCaa,
+  resolveCname,
+  resolveMx,
+  resolveNaptr,
+  resolveNs,
+  resolvePtr,
+  resolveSoa,
+  resolveSrv,
+  resolveTxt,
+  reverse,
+  setDefaultResultOrder,
+  setServers,
+};

--- a/src/runtime/node/dns/promises/index.ts
+++ b/src/runtime/node/dns/promises/index.ts
@@ -1,13 +1,12 @@
-import noop from "../../mock/noop";
-import mock from "../../mock/proxy";
+import noop from "../../../mock/noop";
+import mock from "../../../mock/proxy";
 import {
   notImplemented,
   notImplementedAsync,
 } from "src/runtime/_internal/utils";
-import type dns from "node:dns";
-import * as constants from "./constants";
-import promises from "./promises";
-export * from "./constants";
+import type dns from "node:dns/promises";
+import * as constants from "../constants";
+export * from "../constants";
 
 export const Resolver: typeof dns.Resolver =
   mock.__createMock__("dns.Resolver");
@@ -54,7 +53,6 @@ export default <typeof dns>{
   getServers,
   lookup,
   lookupService,
-  promises,
   resolve,
   resolve4,
   resolve6,

--- a/src/runtime/node/fs/_fs.ts
+++ b/src/runtime/node/fs/_fs.ts
@@ -1,19 +1,6 @@
 import type fs from "node:fs";
-import { notImplemented } from "../../_internal/utils";
+import { notImplemented, notImplementedAsync } from "../../_internal/utils";
 import * as fsp from "./promises/_promises";
-
-interface Promisifiable {
-  (): any;
-  native: Promisifiable;
-  __promisify__: () => Promise<any>;
-}
-
-function notImplementedAsync(name: string): Promisifiable {
-  const fn = notImplemented(name) as any;
-  fn.__promisify__ = () => notImplemented(name + ".__promisify__");
-  fn.native = fn;
-  return fn;
-}
 
 function callbackify(fn: (...args: any[]) => Promise<any>) {
   const fnc = function (...args: any[]) {


### PR DESCRIPTION
Replaces the current auto-mocking of 'dns' to support destructured ESM imports and allow for functional polyfill coverage in the future.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a polyfill for the `node:dns` module.

Also moves the helpful `notImplementedAsync` helper to `utils` from `fs` so that it can be reused.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
