### PR TITLE
feat(node:cluster): polyfill `node:cluster` module

### DIFF
--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -13,6 +13,7 @@ const nodeless: Preset & { alias: Map<string, string> } = {
         "async_hooks",
         "buffer",
         "console",
+        "cluster",
         "crypto",
         "events",
         "fs",

--- a/src/runtime/node/cluster/index.ts
+++ b/src/runtime/node/cluster/index.ts
@@ -22,8 +22,8 @@ const _cluster = new EventEmitter() as MutableCluster;
 export const disconnect: typeof cluster.disconnect = noop;
 export const fork: typeof cluster.fork = () =>
   mock.__createMock__("cluster.Worker");
-export const isPrimary: typeof cluster.isPrimary = true;
 export const isMaster: typeof cluster.isMaster = true;
+export const isPrimary: typeof cluster.isPrimary = true;
 export const isWorker: typeof cluster.isWorker = false;
 export const SCHED_NONE: typeof cluster.SCHED_NONE = 1;
 export const SCHED_RR: typeof cluster.SCHED_RR = 2;
@@ -36,8 +36,8 @@ export const Worker: typeof _Worker = mock.__createMock__("cluster.Worker");
 
 _cluster.disconnect = disconnect;
 _cluster.fork = fork;
-_cluster.isPrimary = isPrimary;
 _cluster.isMaster = isMaster;
+_cluster.isPrimary = isPrimary;
 _cluster.isWorker = isWorker;
 _cluster.SCHED_NONE = SCHED_NONE;
 _cluster.SCHED_RR = SCHED_RR;

--- a/src/runtime/node/cluster/index.ts
+++ b/src/runtime/node/cluster/index.ts
@@ -1,12 +1,9 @@
+// Reference: https://github.com/nodejs/node/blob/main/lib/internal/cluster/primary.js
 import noop from "../../mock/noop";
 import mock from "../../mock/proxy";
 import type cluster from "node:cluster";
 import type { Cluster, Worker as _Worker } from "node:cluster";
 import { EventEmitter } from "../events";
-/**
- * Inspired by the original Node.js code in:
- * https://github.com/nodejs/node/blob/main/lib/internal/cluster/primary.js
- */
 
 // A mapped type used internally to allow assigning to readonly fields like `isPrimary`
 type MutableCluster = {

--- a/src/runtime/node/cluster/index.ts
+++ b/src/runtime/node/cluster/index.ts
@@ -3,7 +3,6 @@ import mock from "../../mock/proxy";
 import type cluster from "node:cluster";
 import type { Cluster, Worker as _Worker } from "node:cluster";
 import { EventEmitter } from "../events";
-
 /**
  * Inspired by the original Node.js code in:
  * https://github.com/nodejs/node/blob/main/lib/internal/cluster/primary.js
@@ -33,6 +32,11 @@ export const setupPrimary: typeof cluster.setupPrimary = noop;
 export const setupMaster: typeof cluster.setupMaster = noop;
 export const workers: typeof cluster.workers = {};
 export const Worker: typeof _Worker = mock.__createMock__("cluster.Worker");
+
+// These 3 _functions don't exist on the EventEmitter type
+export const _events = (_cluster as any)._events;
+export const _eventsCount = (_cluster as any)._eventsCount;
+export const _maxListeners = (_cluster as any)._maxListeners;
 
 _cluster.disconnect = disconnect;
 _cluster.fork = fork;

--- a/src/runtime/node/cluster/index.ts
+++ b/src/runtime/node/cluster/index.ts
@@ -1,0 +1,82 @@
+import { notImplemented } from "src/runtime/_internal/utils";
+import noop from "../../mock/noop";
+import mock from "../../mock/proxy";
+import type cluster from "node:cluster";
+import type { Cluster, Worker as _Worker } from "node:cluster";
+import { EventEmitter } from "../events";
+
+const _cluster = new EventEmitter() as Cluster;
+const _noop = () => {
+  return _cluster;
+};
+
+const on: typeof cluster.on = _noop;
+const addListener: typeof cluster.addListener = _noop;
+const once: typeof cluster.once = _noop;
+const removeListener: typeof cluster.removeListener = _noop;
+const removeAllListeners: typeof cluster.removeAllListeners = _noop;
+const emit: typeof cluster.emit = () => false;
+const off: typeof cluster.off = _noop;
+const prependListener: typeof cluster.prependListener = _noop;
+const prependOnceListener: typeof cluster.prependOnceListener = _noop;
+const listeners: typeof cluster.listeners = function (name) {
+  return [];
+};
+const listenerCount: typeof cluster.listenerCount = () => 0;
+const setMaxListeners: typeof cluster.setMaxListeners = notImplemented(
+  "cluster.setMaxListeners",
+);
+const getMaxListeners: typeof cluster.getMaxListeners = notImplemented(
+  "cluster.getMaxListeners",
+);
+const rawListeners: typeof cluster.rawListeners = notImplemented(
+  "cluster.rawListeners",
+);
+const eventNames: typeof cluster.eventNames =
+  notImplemented("cluster.eventNames");
+
+export const disconnect: typeof cluster.disconnect =
+  notImplemented("cluster.disconnect");
+export const fork: typeof cluster.fork = notImplemented("cluster.fork");
+export const isPrimary: typeof cluster.isPrimary = true;
+export const isMaster: typeof cluster.isMaster = true;
+export const isWorker: typeof cluster.isWorker = false;
+export const SCHED_NONE: typeof cluster.SCHED_NONE = 1;
+export const SCHED_RR: typeof cluster.SCHED_RR = 2;
+export const schedulingPolicy: typeof cluster.schedulingPolicy = SCHED_RR;
+export const settings: typeof cluster.settings = {};
+export const setupPrimary: typeof cluster.setupPrimary = noop;
+export const setupMaster: typeof cluster.setupMaster = noop;
+export const workers: typeof cluster.workers = {};
+export const Worker: typeof _Worker = mock.__createMock__("cluster.Worker");
+
+export default <typeof cluster>{
+  addListener,
+  disconnect,
+  emit,
+  eventNames,
+  fork,
+  getMaxListeners,
+  isMaster,
+  isPrimary,
+  isWorker,
+  listeners,
+  listenerCount,
+  on,
+  once,
+  off,
+  prependListener,
+  prependOnceListener,
+  rawListeners,
+  removeAllListeners,
+  removeListener,
+  SCHED_NONE,
+  SCHED_RR,
+  schedulingPolicy,
+  setMaxListeners,
+  settings,
+  setupPrimary,
+  setupMaster,
+  Worker,
+  workers,
+};

--- a/src/runtime/node/events/_events.ts
+++ b/src/runtime/node/events/_events.ts
@@ -37,6 +37,8 @@ export class EventEmitter implements nodeEvents.EventEmitter {
   _events: Record<string, Listener[] & { warned?: boolean }> =
     Object.create(null);
 
+  _eventsCount = 0;
+
   _maxListeners: undefined | number;
 
   static get defaultMaxListeners() {
@@ -102,6 +104,7 @@ export class EventEmitter implements nodeEvents.EventEmitter {
   }
 
   addListener(type: string, listener: Listener) {
+    this._eventsCount++;
     return _addListener(this, type, listener, false);
   }
 
@@ -122,6 +125,7 @@ export class EventEmitter implements nodeEvents.EventEmitter {
   }
 
   removeListener(type: string, listener: Listener) {
+    this._eventsCount--;
     return _removeListener(this, type, listener);
   }
 
@@ -130,6 +134,7 @@ export class EventEmitter implements nodeEvents.EventEmitter {
   }
 
   removeAllListeners(type: string) {
+    this._eventsCount = 0;
     return _removeAllListeners(this, type);
   }
 


### PR DESCRIPTION
Replaces the current auto-mocking of 'cluster' to support destructured ESM imports and allow for functional polyfill coverage in the future.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a polyfill for the `node:cluster` module.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
