### PR TITLE
feat(node:child_process): polyfill `node:child_process` module

### DIFF
--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -13,6 +13,7 @@ const nodeless: Preset & { alias: Map<string, string> } = {
         "async_hooks",
         "buffer",
         "console",
+        "child_process",
         "cluster",
         "crypto",
         "dns",

--- a/src/runtime/node/child_process/index.ts
+++ b/src/runtime/node/child_process/index.ts
@@ -1,0 +1,42 @@
+import {
+  notImplemented,
+  notImplementedClass,
+} from "src/runtime/_internal/utils";
+import type child_process from "node:child_process";
+
+export const ChildProcess: typeof child_process.ChildProcess =
+  notImplementedClass("child_process.ChildProcess");
+
+export const _forkChild = notImplemented("child_process.ChildProcess");
+
+export const exec: typeof child_process.exec =
+  notImplemented("child_process.exec");
+export const execFile: typeof child_process.execFile = notImplemented(
+  "child_process.execFile",
+);
+export const execFileSync: typeof child_process.execFileSync = notImplemented(
+  "child_process.execFileSync",
+);
+export const execSync: typeof child_process.execSync = notImplemented(
+  "child_process.execSyn",
+);
+export const fork: typeof child_process.fork =
+  notImplemented("child_process.fork");
+export const spawn: typeof child_process.spawn = notImplemented(
+  "child_process.spawn",
+);
+export const spawnSync: typeof child_process.spawnSync = notImplemented(
+  "child_process.spawnSync",
+);
+
+export default <typeof child_process>{
+  ChildProcess,
+  _forkChild,
+  exec,
+  execFile,
+  execFileSync,
+  execSync,
+  fork,
+  spawn,
+  spawnSync,
+};


### PR DESCRIPTION
Replaces the current auto-mocking of 'child_process' to support destructured ESM imports and allow for functional polyfill coverage in the future.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a polyfill for `child_process` module and includes in `nodeless` preset.

@pi0 you think it's ok to mark these as `notImplemented`?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
