### PR TITLE
feat: polyfill `node:dgram` module

### DIFF
--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -16,6 +16,7 @@ const nodeless: Preset & { alias: Map<string, string> } = {
         "child_process",
         "cluster",
         "crypto",
+        "dgram",
         "dns",
         "dns/promises",
         "events",

--- a/src/runtime/node/dgram/index.ts
+++ b/src/runtime/node/dgram/index.ts
@@ -5,6 +5,7 @@ import { Socket } from "./socket";
 export { Socket } from "./socket";
 
 export const _createSocketHandle = noop;
+
 export const createSocket: typeof dgram.createSocket = function () {
   return new Socket();
 };

--- a/src/runtime/node/dgram/index.ts
+++ b/src/runtime/node/dgram/index.ts
@@ -1,0 +1,16 @@
+import noop from "../../mock/noop";
+import type dgram from "node:dgram";
+import { Socket } from "./socket";
+
+export { Socket } from "./socket";
+
+export const _createSocketHandle = noop;
+export const createSocket: typeof dgram.createSocket = function () {
+  return new Socket();
+};
+
+export default <typeof dgram>{
+  Socket,
+  _createSocketHandle,
+  createSocket,
+};

--- a/src/runtime/node/dgram/socket.ts
+++ b/src/runtime/node/dgram/socket.ts
@@ -1,0 +1,65 @@
+import { EventEmitter } from "../events";
+import noop from "../../mock/noop";
+import type net from "node:net";
+import type dgram from "node:dgram";
+
+export class Socket extends EventEmitter implements dgram.Socket {
+  readonly __unenv__ = true;
+
+  bind(): this {
+    return this;
+  }
+  close(): this {
+    return this;
+  }
+  ref(): this {
+    return this;
+  }
+  unref(): this {
+    return this;
+  }
+  getRecvBufferSize(): number {
+    return 100_000;
+  }
+  getSendBufferSize(): number {
+    return 10_000;
+  }
+  getSendQueueSize(): number {
+    return 0;
+  }
+  getSendQueueCount(): number {
+    return 0;
+  }
+  setMulticastLoopback(): boolean {
+    return false;
+  }
+  setMulticastTTL(): number {
+    return 1;
+  }
+  setTTL(): number {
+    return 1;
+  }
+  address(): net.AddressInfo {
+    return { address: "0.0.0.0", family: "IPv4", port: 1234 };
+  }
+
+  remoteAddress(): net.AddressInfo {
+    throw new Error("ERR_SOCKET_DGRAM_NOT_CONNECTED");
+  }
+
+  [Symbol.asyncDispose]() {
+    return Promise.resolve();
+  }
+
+  addMembership = noop;
+  addSourceSpecificMembership = noop;
+  connect = noop;
+  disconnect = noop;
+  dropMembership = noop;
+  dropSourceSpecificMembership = noop;
+  send = noop;
+  setSendBufferSize = noop;
+  setBroadcast = noop;
+  setRecvBufferSize = noop;
+  setMulticastInterface = noop;
+}

--- a/src/runtime/node/dgram/socket.ts
+++ b/src/runtime/node/dgram/socket.ts
@@ -3,6 +3,7 @@ import noop from "../../mock/noop";
 import type net from "node:net";
 import type dgram from "node:dgram";
 
+// eslint-disable-next-line unicorn/prefer-event-target
 export class Socket extends EventEmitter implements dgram.Socket {
   readonly __unenv__ = true;
 

--- a/src/runtime/node/dgram/socket.ts
+++ b/src/runtime/node/dgram/socket.ts
@@ -41,7 +41,7 @@ export class Socket extends EventEmitter implements dgram.Socket {
     return 1;
   }
   address(): net.AddressInfo {
-    return { address: "0.0.0.0", family: "IPv4", port: 1234 };
+    return { address: "127.0.0.1", family: "IPv4", port: 1234 };
   }
 
   remoteAddress(): net.AddressInfo {
@@ -52,15 +52,15 @@ export class Socket extends EventEmitter implements dgram.Socket {
     return Promise.resolve();
   }
 
-  addMembership = noop;
-  addSourceSpecificMembership = noop;
-  connect = noop;
-  disconnect = noop;
-  dropMembership = noop;
-  dropSourceSpecificMembership = noop;
-  send = noop;
-  setSendBufferSize = noop;
-  setBroadcast = noop;
-  setRecvBufferSize = noop;
-  setMulticastInterface = noop;
+  addMembership() {}
+  addSourceSpecificMembership() {}
+  connect() {}
+  disconnect() {}
+  dropMembership() {}
+  dropSourceSpecificMembership() {}
+  send() {}
+  setSendBufferSize() {}
+  setBroadcast() {}
+  setRecvBufferSize() {}
+  setMulticastInterface() {}
 }


### PR DESCRIPTION
Replaces the current auto-mocking of 'dgram' to support destructured ESM imports and allow for functional polyfill coverage in the future.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Polyfills the `node:dgram` module.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
