### PR TITLE
feat: polyfill `node:domain` module

### DIFF
--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -18,6 +18,7 @@ const nodeless: Preset & { alias: Map<string, string> } = {
         "crypto",
         "dns",
         "dns/promises",
+        "domain",
         "events",
         "fs",
         "fs/promises",

--- a/src/runtime/node/domain/_domain.ts
+++ b/src/runtime/node/domain/_domain.ts
@@ -1,0 +1,18 @@
+import { notImplemented } from "../../_internal/utils";
+import noop from "../../mock/noop";
+import { EventEmitter } from "../events";
+import type domain from "node:domain";
+
+// eslint-disable-next-line unicorn/prefer-event-target
+export class Domain extends EventEmitter implements domain.Domain {
+  readonly __unenv__ = true;
+
+  members = [];
+  add = noop;
+  enter = noop;
+  exit = noop;
+  remove = noop;
+  bind = notImplemented("Domain.bind");
+  intercept = notImplemented("Domain.bind");
+  run = notImplemented("Domain.bind");
+}

--- a/src/runtime/node/domain/_domain.ts
+++ b/src/runtime/node/domain/_domain.ts
@@ -1,5 +1,4 @@
-import { notImplemented } from "../../_internal/utils";
-import noop from "../../mock/noop";
+import { createNotImplementedError } from "../../_internal/utils";
 import { EventEmitter } from "../events";
 import type domain from "node:domain";
 
@@ -8,11 +7,17 @@ export class Domain extends EventEmitter implements domain.Domain {
   readonly __unenv__ = true;
 
   members = [];
-  add = noop;
-  enter = noop;
-  exit = noop;
-  remove = noop;
-  bind = notImplemented("Domain.bind");
-  intercept = notImplemented("Domain.bind");
-  run = notImplemented("Domain.bind");
+  add() {}
+  enter() {}
+  exit() {}
+  remove() {}
+  bind<T>(callback: T): T {
+    throw createNotImplementedError("Domain.bind");
+  }
+  intercept<T>(callback: T): T {
+    throw createNotImplementedError("Domain.intercept");
+  }
+  run<T>(fn: (...args: any[]) => T, ...args: any[]): T {
+    throw createNotImplementedError("Domain.run");
+  }
 }

--- a/src/runtime/node/domain/index.ts
+++ b/src/runtime/node/domain/index.ts
@@ -1,0 +1,20 @@
+import type domain from "node:domain";
+import { Domain } from "./_domain";
+
+export { Domain } from "./_domain";
+
+export const create: typeof domain.create = function () {
+  return new Domain();
+};
+export const createDomain: typeof domain.create = create;
+const _domain = create();
+export const active = () => _domain;
+export const _stack = [];
+
+export default <typeof domain>{
+  Domain,
+  _stack,
+  active,
+  create,
+  createDomain,
+};


### PR DESCRIPTION
Replaces the current auto-mocking of 'domain' to support destructured ESM imports and allow for functional polyfill coverage in the future.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Polyfills the `node:domain` module.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
