### PR TITLE
feat(nodeless): add the `node:https` module

### DIFF
--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -21,6 +21,7 @@ const nodeless: Preset & { alias: Map<string, string> } = {
         "fs",
         "fs/promises",
         "http",
+        "https",
         "net",
         "os",
         "path",

--- a/src/runtime/node/https/index.ts
+++ b/src/runtime/node/https/index.ts
@@ -1,13 +1,16 @@
 // https://nodejs.org/api/https.html
 import type nodeHttps from "node:https";
 import { notImplemented, notImplementedClass } from "../../_internal/utils";
+import mock from "../../mock/proxy";
 
 export const Server: typeof nodeHttps.Server =
   notImplementedClass("https.Server");
 
 export const Agent: typeof nodeHttps.Agent = notImplementedClass("https.Agent");
 
-export const globalAgent = undefined as any as typeof nodeHttps.globalAgent;
+export const globalAgent =
+  (undefined as any as typeof nodeHttps.globalAgent) ||
+  mock.__createMock__("https.globalAgent");
 
 export const get = notImplemented<typeof nodeHttps.get>("https.get");
 


### PR DESCRIPTION


<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds the https module to the nodeless preset. Also adds a mock fallback for `globalAgent`.

@pi0 was there any reason why this wasn't added already?


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
