### PR TITLE
feat: polyfill `node:querystring` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "defu": "^6.1.4",
     "mime": "^3.0.0",
     "node-fetch-native": "^1.6.4",
-    "pathe": "^1.1.2"
+    "pathe": "^1.1.2",
+    "ufo": "^1.5.3"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       pathe:
         specifier: ^1.1.2
         version: 1.1.2
+      ufo:
+        specifier: ^1.5.3
+        version: 1.5.3
     devDependencies:
       '@types/node':
         specifier: ^20.12.12

--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -27,6 +27,7 @@ const nodeless: Preset & { alias: Map<string, string> } = {
         "os",
         "path",
         "process",
+        "querystring",
         "stream",
         "stream/promises",
         "stream/consumers",

--- a/src/runtime/node/querystring/index.ts
+++ b/src/runtime/node/querystring/index.ts
@@ -4,24 +4,33 @@ import { parseQuery, stringifyQuery } from "ufo";
 import type { QueryObject } from "ufo";
 import type querystring from "node:querystring";
 
-const _stringify: typeof querystring.stringify = function (obj) {
-  return stringifyQuery(obj as QueryObject);
-};
-const _parse: typeof querystring.parse = function (obj) {
+export const parse: typeof querystring.parse = function (
+  obj,
+  _sep,
+  _eq,
+  _options,
+) {
   return parseQuery(obj);
 };
+export const decode: typeof querystring.decode = parse;
 
-export const decode: typeof querystring.decode = _parse;
-export const parse: typeof querystring.parse = _parse;
-export const encode: typeof querystring.encode = _stringify;
-export const stringify: typeof querystring.stringify = _stringify;
+export const stringify: typeof querystring.stringify = function (
+  obj,
+  _sep,
+  _eq,
+  _options,
+) {
+  return stringifyQuery(obj as QueryObject);
+};
+export const encode: typeof querystring.encode = stringify;
 
 // eslint-disable-next-line prefer-const
 export let escape: typeof querystring.escape = encodeURIComponent;
+
 // eslint-disable-next-line prefer-const
 export let unescape: typeof querystring.unescape = decodeURIComponent;
 
-export const unescapeBuffer = function (str: string) {
+export const unescapeBuffer = function (str: string, _decodeSpaces: boolean) {
   return Buffer.from(unescape(str));
 };
 

--- a/src/runtime/node/querystring/index.ts
+++ b/src/runtime/node/querystring/index.ts
@@ -1,25 +1,20 @@
-import {
-  parseQuery,
-  stringifyQuery,
-  encode as _encode,
-  decode as _decode,
-} from "ufo";
+import { parseQuery, stringifyQuery } from "ufo";
 import type { QueryObject } from "ufo";
 import type querystring from "node:querystring";
-import { notImplemented } from "src/runtime/_internal/utils";
 
 const _stringify: typeof querystring.stringify = function (obj) {
   return stringifyQuery(obj as QueryObject);
 };
 export const decode: typeof querystring.decode = parseQuery;
 export const encode: typeof querystring.encode = _stringify;
-export const escape: typeof querystring.escape = _encode;
 export const parse: typeof querystring.parse = parseQuery;
 export const stringify: typeof querystring.stringify = _stringify;
-export const unescape: typeof querystring.unescape = _decode;
-export const unescapeBuffer: typeof querystring.unescape = notImplemented(
-  "querystring.unescapeBuffer",
-);
+
+export let escape: typeof querystring.escape = encodeURIComponent;
+export let unescape: typeof querystring.unescape = decodeURIComponent;
+export const unescapeBuffer = function (str: string) {
+  return Buffer.from(unescape(str));
+};
 
 export default <typeof querystring>{
   decode,

--- a/src/runtime/node/querystring/index.ts
+++ b/src/runtime/node/querystring/index.ts
@@ -1,3 +1,5 @@
+// https://nodejs.org/api/querystring.html
+
 import { parseQuery, stringifyQuery } from "ufo";
 import type { QueryObject } from "ufo";
 import type querystring from "node:querystring";
@@ -5,13 +7,20 @@ import type querystring from "node:querystring";
 const _stringify: typeof querystring.stringify = function (obj) {
   return stringifyQuery(obj as QueryObject);
 };
-export const decode: typeof querystring.decode = parseQuery;
+const _parse: typeof querystring.parse = function (obj) {
+  return parseQuery(obj);
+};
+
+export const decode: typeof querystring.decode = _parse;
+export const parse: typeof querystring.parse = _parse;
 export const encode: typeof querystring.encode = _stringify;
-export const parse: typeof querystring.parse = parseQuery;
 export const stringify: typeof querystring.stringify = _stringify;
 
+// eslint-disable-next-line prefer-const
 export let escape: typeof querystring.escape = encodeURIComponent;
+// eslint-disable-next-line prefer-const
 export let unescape: typeof querystring.unescape = decodeURIComponent;
+
 export const unescapeBuffer = function (str: string) {
   return Buffer.from(unescape(str));
 };

--- a/src/runtime/node/querystring/index.ts
+++ b/src/runtime/node/querystring/index.ts
@@ -1,0 +1,32 @@
+import {
+  parseQuery,
+  stringifyQuery,
+  encode as _encode,
+  decode as _decode,
+} from "ufo";
+import type { QueryObject } from "ufo";
+import type querystring from "node:querystring";
+import { notImplemented } from "src/runtime/_internal/utils";
+
+const _stringify: typeof querystring.stringify = function (obj) {
+  return stringifyQuery(obj as QueryObject);
+};
+export const decode: typeof querystring.decode = parseQuery;
+export const encode: typeof querystring.encode = _stringify;
+export const escape: typeof querystring.escape = _encode;
+export const parse: typeof querystring.parse = parseQuery;
+export const stringify: typeof querystring.stringify = _stringify;
+export const unescape: typeof querystring.unescape = _decode;
+export const unescapeBuffer: typeof querystring.unescape = notImplemented(
+  "querystring.unescapeBuffer",
+);
+
+export default <typeof querystring>{
+  decode,
+  encode,
+  escape,
+  parse,
+  stringify,
+  unescape,
+  unescapeBuffer,
+};


### PR DESCRIPTION
Replaces the current auto-mocking of 'querystring' to support destructured ESM imports and allow for functional polyfill coverage in the future.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Uses `ufo` to add a functional polyfill for the `querystring` module.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
