### PR TITLE
feat: basic web performances api implementation

### DIFF
--- a/src/runtime/web/performance/_entry.ts
+++ b/src/runtime/web/performance/_entry.ts
@@ -1,0 +1,95 @@
+// https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/supportedEntryTypes_static
+export const supportedEntryTypes = [
+  "event", // PerformanceEntry
+  "mark", // PerformanceMark
+  "measure", // PerformanceMeasure
+  "resource", // PerformanceResourceTiming
+] as const;
+export type PerformanceEntryType = (typeof supportedEntryTypes)[number];
+
+// https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry
+export class _PerformanceEntry implements globalThis.PerformanceEntry {
+  detail: any;
+  entryType: PerformanceEntryType = "event";
+
+  name: string;
+  startTime: number;
+
+  constructor(name: string, options?: PerformanceMarkOptions) {
+    this.name = name;
+    this.startTime = options?.startTime || performance.now();
+    this.detail = options?.detail;
+  }
+
+  get duration(): number {
+    return performance.now() - this.startTime;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      entryType: this.entryType,
+      startTime: this.startTime,
+      duration: this.duration,
+      detail: this.detail,
+    };
+  }
+}
+export const PerformanceEntry: typeof globalThis.PerformanceEntry =
+  globalThis.PerformanceEntry || _PerformanceEntry;
+
+// https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMark
+export const PerformanceMark: typeof globalThis.PerformanceMark =
+  globalThis.PerformanceMark ||
+  class PerformanceMark
+    extends PerformanceEntry
+    implements globalThis.PerformanceMark
+  {
+    detail: any;
+    entryType = "mark";
+  };
+
+// https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMeasure
+export const PerformanceMeasure: typeof globalThis.PerformanceMeasure =
+  globalThis.PerformanceMeasure ||
+  class PerformanceMeasure
+    extends PerformanceEntry
+    implements globalThis.PerformanceMeasure
+  {
+    detail: any;
+    entryType = "measure";
+  };
+
+// https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming
+export const PerformanceResourceTiming: typeof globalThis.PerformanceResourceTiming =
+  globalThis.PerformanceResourceTiming ||
+  class PerformanceResourceTiming
+    extends PerformanceEntry
+    implements globalThis.PerformanceResourceTiming
+  {
+    entryType = "resource";
+    serverTiming: readonly PerformanceServerTiming[] = [];
+    connectEnd = 0;
+    connectStart = 0;
+    decodedBodySize = 0;
+    domainLookupEnd = 0;
+    domainLookupStart = 0;
+    duration = 0;
+    encodedBodySize = 0;
+    fetchStart = 0;
+    initiatorType = "";
+    name = "";
+    nextHopProtocol = "";
+    redirectEnd = 0;
+    redirectStart = 0;
+    requestStart = 0;
+    responseEnd = 0;
+    responseStart = 0;
+    secureConnectionStart = 0;
+    startTime = 0;
+    transferSize = 0;
+    workerStart = 0;
+    toJSON() {
+      return this;
+    }
+  };

--- a/src/runtime/web/performance/_observer.ts
+++ b/src/runtime/web/performance/_observer.ts
@@ -1,0 +1,49 @@
+import { createNotImplementedError } from "../../_internal/utils";
+import { supportedEntryTypes } from "./_entry";
+
+// https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver
+export const PerformanceObserver: typeof globalThis.PerformanceObserver =
+  globalThis.PerformanceObserver ||
+  class _PerformanceObserver implements globalThis.PerformanceObserver {
+    static supportedEntryTypes: ReadonlyArray<string> = supportedEntryTypes;
+
+    _callback: PerformanceObserverCallback | null = null;
+
+    constructor(callback: PerformanceObserverCallback) {
+      this._callback = callback;
+    }
+
+    takeRecords(): PerformanceEntryList {
+      return [];
+    }
+
+    disconnect(): void {
+      throw createNotImplementedError("PerformanceObserver.disconnect");
+    }
+
+    observe(options: PerformanceObserverInit): void {
+      throw createNotImplementedError("PerformanceObserver.observe");
+    }
+  };
+
+// https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserverEntryList
+export const PerformanceObserverEntryList: typeof globalThis.PerformanceObserverEntryList =
+  globalThis.PerformanceObserverEntryList ||
+  class _PerformanceObserverEntryList
+    implements globalThis.PerformanceObserverEntryList
+  {
+    getEntries(): PerformanceEntryList {
+      return [];
+    }
+
+    getEntriesByName(
+      _name: string,
+      _type?: string | undefined,
+    ): PerformanceEntryList {
+      return [];
+    }
+
+    getEntriesByType(type: string): PerformanceEntryList {
+      return [];
+    }
+  };

--- a/src/runtime/web/performance/_performance.ts
+++ b/src/runtime/web/performance/_performance.ts
@@ -1,0 +1,153 @@
+import { createNotImplementedError } from "../../_internal/utils";
+import mock from "../../mock/proxy";
+import { _PerformanceEntry } from "./_entry";
+
+const _timeOrigin = Date.now();
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Performance
+export const Performance: typeof globalThis.Performance =
+  globalThis.Performance ||
+  class _Performance implements globalThis.Performance {
+    timeOrigin: number = _timeOrigin;
+
+    eventCounts: EventCounts = new Map<string, number>();
+
+    _entries: PerformanceEntry[] = [];
+    _resourceTimingBufferSize = 0;
+
+    navigation = mock.__createMock__("PerformanceNavigation");
+    timing = mock.__createMock__("PerformanceTiming");
+
+    onresourcetimingbufferfull: ((this: Performance, ev: Event) => any) | null =
+      null;
+
+    now(): number {
+      // https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
+      // performance.now() - (Date.now()-performance.timeOrigin) ~= 0
+      return Date.now() - this.timeOrigin;
+    }
+
+    mark(
+      name: string,
+      options?: PerformanceMarkOptions | undefined,
+    ): PerformanceMark {
+      const entry = new _PerformanceEntry(name, options);
+      entry.entryType = "mark";
+      this._entries.push(entry);
+      return entry as PerformanceMark;
+    }
+
+    clearMarks(markName?: string | undefined): void {
+      this._entries = markName
+        ? this._entries.filter((e) => e.name !== markName)
+        : this._entries.filter((e) => e.entryType !== "mark");
+    }
+
+    clearMeasures(measureName?: string | undefined): void {
+      this._entries = measureName
+        ? this._entries.filter((e) => e.name !== measureName)
+        : this._entries.filter((e) => e.entryType !== "measure");
+    }
+
+    clearResourceTimings(): void {
+      this._entries = this._entries.filter(
+        (e) =>
+          e.entryType !== "resource" || (e.entryType as any) !== "navigation",
+      );
+    }
+
+    getEntries(): PerformanceEntry[] {
+      return this._entries;
+    }
+
+    getEntriesByName(
+      name: string,
+      type?: string | undefined,
+    ): PerformanceEntry[] {
+      return this._entries.filter(
+        (e) => e.name === name && (!type || e.entryType === type),
+      );
+    }
+
+    getEntriesByType(type: string): PerformanceEntry[] {
+      return this._entries.filter((e) => e.entryType === type);
+    }
+
+    measure(
+      measureName: string,
+      startOrMeasureOptions?: string | PerformanceMeasureOptions,
+      endMark?: string,
+    ): PerformanceMeasure {
+      let start: number;
+      let end: number;
+      if (typeof startOrMeasureOptions === "string") {
+        start = this.getEntriesByName(startOrMeasureOptions, "mark")[0]
+          .startTime;
+        end = this.getEntriesByName(endMark!, "mark")[0].startTime;
+      } else {
+        start =
+          Number.parseFloat(startOrMeasureOptions?.start as string) ||
+          performance.now();
+        end =
+          Number.parseFloat(startOrMeasureOptions?.end as string) ||
+          performance.now();
+      }
+      const entry = new _PerformanceEntry(measureName);
+      entry.entryType = "measure";
+      entry.startTime = start;
+      entry.detail = { start, end };
+      this._entries.push(entry);
+      return entry as PerformanceMeasure;
+    }
+
+    setResourceTimingBufferSize(maxSize: number): void {
+      this._resourceTimingBufferSize = maxSize;
+    }
+
+    toJSON() {
+      return this;
+    }
+
+    addEventListener<K extends "resourcetimingbufferfull">(
+      type: K,
+      listener: (this: Performance, ev: PerformanceEventMap[K]) => any,
+      options?: boolean | AddEventListenerOptions | undefined,
+    ): void;
+    addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions | undefined,
+    ): void;
+    addEventListener(
+      type: unknown,
+      listener: unknown,
+      options?: unknown,
+    ): void {
+      throw createNotImplementedError("Performance.addEventListener");
+    }
+
+    removeEventListener<K extends "resourcetimingbufferfull">(
+      type: K,
+      listener: (this: Performance, ev: PerformanceEventMap[K]) => any,
+      options?: boolean | EventListenerOptions | undefined,
+    ): void;
+    removeEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions | undefined,
+    ): void;
+    removeEventListener(
+      type: unknown,
+      listener: unknown,
+      options?: unknown,
+    ): void {
+      throw createNotImplementedError("Performance.removeEventListener");
+    }
+
+    dispatchEvent(event: Event): boolean {
+      throw createNotImplementedError("Performance.dispatchEvent");
+    }
+  };
+
+export const performance: typeof globalThis.performance =
+  globalThis.performance || new Performance();

--- a/src/runtime/web/performance/index.ts
+++ b/src/runtime/web/performance/index.ts
@@ -1,0 +1,27 @@
+// https://developer.mozilla.org/en-US/docs/Web/API/Performance_API
+
+export { Performance, performance } from "./_performance";
+export { PerformanceObserver, PerformanceObserverEntryList } from "./_observer";
+export {
+  PerformanceEntry,
+  PerformanceMark,
+  PerformanceMeasure,
+  PerformanceResourceTiming,
+} from "./_entry";
+
+// Not implemented:
+// EventCounts
+// PerformanceEventTiming
+// PerformanceLongTaskTiming
+// PerformanceServerTiming
+// TaskAttributionTiming
+// LargestContentfulPaint (browser)
+// LayoutShift (browser)
+// LayoutShiftAttribution (browser)
+// VisibilityStateEntry (browser)
+// PerformancePaintTiming (browser)
+// PerformanceLongAnimationFrameTiming (browser)
+// PerformanceScriptTiming (browser)
+// PerformanceNavigation (browser)
+// PerformanceNavigationTiming (browser)
+// PerformanceElementTiming (browser)


### PR DESCRIPTION
This PR adds a partial (node subset) implementation of web performances API mainly useful for https://github.com/unjs/unenv/pull/209

All expoirts will first try to use `globalThis.*` native version before falling back to polyfills.