### PR TITLE
refactor(web/performance): separate polyfill and native exports

### DIFF
--- a/src/runtime/web/performance/_entry.ts
+++ b/src/runtime/web/performance/_entry.ts
@@ -1,16 +1,18 @@
 // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/supportedEntryTypes_static
-export const supportedEntryTypes = [
+export const _supportedEntryTypes = [
   "event", // PerformanceEntry
   "mark", // PerformanceMark
   "measure", // PerformanceMeasure
   "resource", // PerformanceResourceTiming
 ] as const;
-export type PerformanceEntryType = (typeof supportedEntryTypes)[number];
+export type _PerformanceEntryType = (typeof _supportedEntryTypes)[number];
 
 // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry
 export class _PerformanceEntry implements globalThis.PerformanceEntry {
+  readonly __unenv__ = true;
+
   detail: any;
-  entryType: PerformanceEntryType = "event";
+  entryType: _PerformanceEntryType = "event";
 
   name: string;
   startTime: number;
@@ -35,61 +37,59 @@ export class _PerformanceEntry implements globalThis.PerformanceEntry {
     };
   }
 }
+
 export const PerformanceEntry: typeof globalThis.PerformanceEntry =
   globalThis.PerformanceEntry || _PerformanceEntry;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMark
+export class _PerformanceMark
+  extends _PerformanceEntry
+  implements globalThis.PerformanceMark
+{
+  entryType: _PerformanceEntryType = "mark";
+}
+
 export const PerformanceMark: typeof globalThis.PerformanceMark =
-  globalThis.PerformanceMark ||
-  class PerformanceMark
-    extends PerformanceEntry
-    implements globalThis.PerformanceMark
-  {
-    detail: any;
-    entryType = "mark";
-  };
+  globalThis.PerformanceMark || _PerformanceMark;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMeasure
+export class _PerformanceMeasure
+  extends _PerformanceEntry
+  implements globalThis.PerformanceMeasure
+{
+  entryType: _PerformanceEntryType = "measure";
+}
+
 export const PerformanceMeasure: typeof globalThis.PerformanceMeasure =
-  globalThis.PerformanceMeasure ||
-  class PerformanceMeasure
-    extends PerformanceEntry
-    implements globalThis.PerformanceMeasure
-  {
-    detail: any;
-    entryType = "measure";
-  };
+  globalThis.PerformanceMeasure || _PerformanceMeasure;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming
+export class _PerformanceResourceTiming
+  extends _PerformanceEntry
+  implements globalThis.PerformanceResourceTiming
+{
+  entryType: _PerformanceEntryType = "resource";
+  serverTiming: readonly PerformanceServerTiming[] = [];
+  connectEnd = 0;
+  connectStart = 0;
+  decodedBodySize = 0;
+  domainLookupEnd = 0;
+  domainLookupStart = 0;
+  encodedBodySize = 0;
+  fetchStart = 0;
+  initiatorType = "";
+  name = "";
+  nextHopProtocol = "";
+  redirectEnd = 0;
+  redirectStart = 0;
+  requestStart = 0;
+  responseEnd = 0;
+  responseStart = 0;
+  secureConnectionStart = 0;
+  startTime = 0;
+  transferSize = 0;
+  workerStart = 0;
+}
+
 export const PerformanceResourceTiming: typeof globalThis.PerformanceResourceTiming =
-  globalThis.PerformanceResourceTiming ||
-  class PerformanceResourceTiming
-    extends PerformanceEntry
-    implements globalThis.PerformanceResourceTiming
-  {
-    entryType = "resource";
-    serverTiming: readonly PerformanceServerTiming[] = [];
-    connectEnd = 0;
-    connectStart = 0;
-    decodedBodySize = 0;
-    domainLookupEnd = 0;
-    domainLookupStart = 0;
-    duration = 0;
-    encodedBodySize = 0;
-    fetchStart = 0;
-    initiatorType = "";
-    name = "";
-    nextHopProtocol = "";
-    redirectEnd = 0;
-    redirectStart = 0;
-    requestStart = 0;
-    responseEnd = 0;
-    responseStart = 0;
-    secureConnectionStart = 0;
-    startTime = 0;
-    transferSize = 0;
-    workerStart = 0;
-    toJSON() {
-      return this;
-    }
-  };
+  globalThis.PerformanceResourceTiming || _PerformanceResourceTiming;

--- a/src/runtime/web/performance/_observer.ts
+++ b/src/runtime/web/performance/_observer.ts
@@ -1,49 +1,55 @@
 import { createNotImplementedError } from "../../_internal/utils";
-import { supportedEntryTypes } from "./_entry";
+import { _supportedEntryTypes } from "./_entry";
 
 // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver
+export class _PerformanceObserver implements globalThis.PerformanceObserver {
+  readonly __unenv__ = true;
+
+  static supportedEntryTypes: ReadonlyArray<string> = _supportedEntryTypes;
+
+  _callback: PerformanceObserverCallback | null = null;
+
+  constructor(callback: PerformanceObserverCallback) {
+    this._callback = callback;
+  }
+
+  takeRecords(): PerformanceEntryList {
+    return [];
+  }
+
+  disconnect(): void {
+    throw createNotImplementedError("PerformanceObserver.disconnect");
+  }
+
+  observe(options: PerformanceObserverInit): void {
+    throw createNotImplementedError("PerformanceObserver.observe");
+  }
+}
+
 export const PerformanceObserver: typeof globalThis.PerformanceObserver =
-  globalThis.PerformanceObserver ||
-  class _PerformanceObserver implements globalThis.PerformanceObserver {
-    static supportedEntryTypes: ReadonlyArray<string> = supportedEntryTypes;
-
-    _callback: PerformanceObserverCallback | null = null;
-
-    constructor(callback: PerformanceObserverCallback) {
-      this._callback = callback;
-    }
-
-    takeRecords(): PerformanceEntryList {
-      return [];
-    }
-
-    disconnect(): void {
-      throw createNotImplementedError("PerformanceObserver.disconnect");
-    }
-
-    observe(options: PerformanceObserverInit): void {
-      throw createNotImplementedError("PerformanceObserver.observe");
-    }
-  };
+  globalThis.PerformanceObserver || _PerformanceObserver;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserverEntryList
+export class _PerformanceObserverEntryList
+  implements globalThis.PerformanceObserverEntryList
+{
+  readonly __unenv__ = true;
+
+  getEntries(): PerformanceEntryList {
+    return [];
+  }
+
+  getEntriesByName(
+    _name: string,
+    _type?: string | undefined,
+  ): PerformanceEntryList {
+    return [];
+  }
+
+  getEntriesByType(type: string): PerformanceEntryList {
+    return [];
+  }
+}
+
 export const PerformanceObserverEntryList: typeof globalThis.PerformanceObserverEntryList =
-  globalThis.PerformanceObserverEntryList ||
-  class _PerformanceObserverEntryList
-    implements globalThis.PerformanceObserverEntryList
-  {
-    getEntries(): PerformanceEntryList {
-      return [];
-    }
-
-    getEntriesByName(
-      _name: string,
-      _type?: string | undefined,
-    ): PerformanceEntryList {
-      return [];
-    }
-
-    getEntriesByType(type: string): PerformanceEntryList {
-      return [];
-    }
-  };
+  globalThis.PerformanceObserverEntryList || _PerformanceObserverEntryList;

--- a/src/runtime/web/performance/_performance.ts
+++ b/src/runtime/web/performance/_performance.ts
@@ -1,153 +1,150 @@
 import { createNotImplementedError } from "../../_internal/utils";
 import mock from "../../mock/proxy";
-import { _PerformanceEntry } from "./_entry";
+import { _PerformanceMark, _PerformanceMeasure } from "./_entry";
 
 const _timeOrigin = Date.now();
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Performance
+export class _Performance implements globalThis.Performance {
+  readonly __unenv__ = true;
+
+  timeOrigin: number = _timeOrigin;
+
+  eventCounts: EventCounts = new Map<string, number>();
+
+  _entries: PerformanceEntry[] = [];
+  _resourceTimingBufferSize = 0;
+
+  navigation = mock.__createMock__("PerformanceNavigation");
+  timing = mock.__createMock__("PerformanceTiming");
+
+  onresourcetimingbufferfull: ((this: Performance, ev: Event) => any) | null =
+    null;
+
+  now(): number {
+    // https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
+    // performance.now() - (Date.now()-performance.timeOrigin) ~= 0
+    return Date.now() - this.timeOrigin;
+  }
+
+  clearMarks(markName?: string | undefined): void {
+    this._entries = markName
+      ? this._entries.filter((e) => e.name !== markName)
+      : this._entries.filter((e) => e.entryType !== "mark");
+  }
+
+  clearMeasures(measureName?: string | undefined): void {
+    this._entries = measureName
+      ? this._entries.filter((e) => e.name !== measureName)
+      : this._entries.filter((e) => e.entryType !== "measure");
+  }
+
+  clearResourceTimings(): void {
+    this._entries = this._entries.filter(
+      (e) =>
+        e.entryType !== "resource" || (e.entryType as any) !== "navigation",
+    );
+  }
+
+  getEntries(): PerformanceEntry[] {
+    return this._entries;
+  }
+
+  getEntriesByName(
+    name: string,
+    type?: string | undefined,
+  ): PerformanceEntry[] {
+    return this._entries.filter(
+      (e) => e.name === name && (!type || e.entryType === type),
+    );
+  }
+
+  getEntriesByType(type: string): PerformanceEntry[] {
+    return this._entries.filter((e) => e.entryType === type);
+  }
+
+  mark(
+    name: string,
+    options?: PerformanceMarkOptions | undefined,
+  ): PerformanceMark {
+    const entry = new _PerformanceMark(name, options);
+    this._entries.push(entry);
+    return entry;
+  }
+
+  measure(
+    measureName: string,
+    startOrMeasureOptions?: string | PerformanceMeasureOptions,
+    endMark?: string,
+  ): PerformanceMeasure {
+    let start: number;
+    let end: number;
+    if (typeof startOrMeasureOptions === "string") {
+      start = this.getEntriesByName(startOrMeasureOptions, "mark")[0].startTime;
+      end = this.getEntriesByName(endMark!, "mark")[0].startTime;
+    } else {
+      start =
+        Number.parseFloat(startOrMeasureOptions?.start as string) ||
+        performance.now();
+      end =
+        Number.parseFloat(startOrMeasureOptions?.end as string) ||
+        performance.now();
+    }
+    const entry = new _PerformanceMeasure(measureName, {
+      startTime: start,
+      detail: { start, end },
+    });
+    this._entries.push(entry);
+    return entry;
+  }
+
+  setResourceTimingBufferSize(maxSize: number): void {
+    this._resourceTimingBufferSize = maxSize;
+  }
+
+  toJSON() {
+    return this;
+  }
+
+  addEventListener<K extends "resourcetimingbufferfull">(
+    type: K,
+    listener: (this: Performance, ev: PerformanceEventMap[K]) => any,
+    options?: boolean | AddEventListenerOptions | undefined,
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions | undefined,
+  ): void;
+  addEventListener(type: unknown, listener: unknown, options?: unknown): void {
+    throw createNotImplementedError("Performance.addEventListener");
+  }
+
+  removeEventListener<K extends "resourcetimingbufferfull">(
+    type: K,
+    listener: (this: Performance, ev: PerformanceEventMap[K]) => any,
+    options?: boolean | EventListenerOptions | undefined,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions | undefined,
+  ): void;
+  removeEventListener(
+    type: unknown,
+    listener: unknown,
+    options?: unknown,
+  ): void {
+    throw createNotImplementedError("Performance.removeEventListener");
+  }
+
+  dispatchEvent(event: Event): boolean {
+    throw createNotImplementedError("Performance.dispatchEvent");
+  }
+}
+
 export const Performance: typeof globalThis.Performance =
-  globalThis.Performance ||
-  class _Performance implements globalThis.Performance {
-    timeOrigin: number = _timeOrigin;
-
-    eventCounts: EventCounts = new Map<string, number>();
-
-    _entries: PerformanceEntry[] = [];
-    _resourceTimingBufferSize = 0;
-
-    navigation = mock.__createMock__("PerformanceNavigation");
-    timing = mock.__createMock__("PerformanceTiming");
-
-    onresourcetimingbufferfull: ((this: Performance, ev: Event) => any) | null =
-      null;
-
-    now(): number {
-      // https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
-      // performance.now() - (Date.now()-performance.timeOrigin) ~= 0
-      return Date.now() - this.timeOrigin;
-    }
-
-    mark(
-      name: string,
-      options?: PerformanceMarkOptions | undefined,
-    ): PerformanceMark {
-      const entry = new _PerformanceEntry(name, options);
-      entry.entryType = "mark";
-      this._entries.push(entry);
-      return entry as PerformanceMark;
-    }
-
-    clearMarks(markName?: string | undefined): void {
-      this._entries = markName
-        ? this._entries.filter((e) => e.name !== markName)
-        : this._entries.filter((e) => e.entryType !== "mark");
-    }
-
-    clearMeasures(measureName?: string | undefined): void {
-      this._entries = measureName
-        ? this._entries.filter((e) => e.name !== measureName)
-        : this._entries.filter((e) => e.entryType !== "measure");
-    }
-
-    clearResourceTimings(): void {
-      this._entries = this._entries.filter(
-        (e) =>
-          e.entryType !== "resource" || (e.entryType as any) !== "navigation",
-      );
-    }
-
-    getEntries(): PerformanceEntry[] {
-      return this._entries;
-    }
-
-    getEntriesByName(
-      name: string,
-      type?: string | undefined,
-    ): PerformanceEntry[] {
-      return this._entries.filter(
-        (e) => e.name === name && (!type || e.entryType === type),
-      );
-    }
-
-    getEntriesByType(type: string): PerformanceEntry[] {
-      return this._entries.filter((e) => e.entryType === type);
-    }
-
-    measure(
-      measureName: string,
-      startOrMeasureOptions?: string | PerformanceMeasureOptions,
-      endMark?: string,
-    ): PerformanceMeasure {
-      let start: number;
-      let end: number;
-      if (typeof startOrMeasureOptions === "string") {
-        start = this.getEntriesByName(startOrMeasureOptions, "mark")[0]
-          .startTime;
-        end = this.getEntriesByName(endMark!, "mark")[0].startTime;
-      } else {
-        start =
-          Number.parseFloat(startOrMeasureOptions?.start as string) ||
-          performance.now();
-        end =
-          Number.parseFloat(startOrMeasureOptions?.end as string) ||
-          performance.now();
-      }
-      const entry = new _PerformanceEntry(measureName);
-      entry.entryType = "measure";
-      entry.startTime = start;
-      entry.detail = { start, end };
-      this._entries.push(entry);
-      return entry as PerformanceMeasure;
-    }
-
-    setResourceTimingBufferSize(maxSize: number): void {
-      this._resourceTimingBufferSize = maxSize;
-    }
-
-    toJSON() {
-      return this;
-    }
-
-    addEventListener<K extends "resourcetimingbufferfull">(
-      type: K,
-      listener: (this: Performance, ev: PerformanceEventMap[K]) => any,
-      options?: boolean | AddEventListenerOptions | undefined,
-    ): void;
-    addEventListener(
-      type: string,
-      listener: EventListenerOrEventListenerObject,
-      options?: boolean | AddEventListenerOptions | undefined,
-    ): void;
-    addEventListener(
-      type: unknown,
-      listener: unknown,
-      options?: unknown,
-    ): void {
-      throw createNotImplementedError("Performance.addEventListener");
-    }
-
-    removeEventListener<K extends "resourcetimingbufferfull">(
-      type: K,
-      listener: (this: Performance, ev: PerformanceEventMap[K]) => any,
-      options?: boolean | EventListenerOptions | undefined,
-    ): void;
-    removeEventListener(
-      type: string,
-      listener: EventListenerOrEventListenerObject,
-      options?: boolean | EventListenerOptions | undefined,
-    ): void;
-    removeEventListener(
-      type: unknown,
-      listener: unknown,
-      options?: unknown,
-    ): void {
-      throw createNotImplementedError("Performance.removeEventListener");
-    }
-
-    dispatchEvent(event: Event): boolean {
-      throw createNotImplementedError("Performance.dispatchEvent");
-    }
-  };
+  globalThis.Performance || _Performance;
 
 export const performance: typeof globalThis.performance =
   globalThis.performance || new Performance();

--- a/src/runtime/web/performance/_performance.ts
+++ b/src/runtime/web/performance/_performance.ts
@@ -23,6 +23,10 @@ export class _Performance implements globalThis.Performance {
 
   now(): number {
     // https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
+    // Prefer performance.now() if available
+    if (globalThis?.performance?.now && this.timeOrigin === _timeOrigin) {
+      return globalThis.performance.now();
+    }
     // performance.now() - (Date.now()-performance.timeOrigin) ~= 0
     return Date.now() - this.timeOrigin;
   }

--- a/src/runtime/web/performance/index.ts
+++ b/src/runtime/web/performance/index.ts
@@ -1,12 +1,23 @@
 // https://developer.mozilla.org/en-US/docs/Web/API/Performance_API
 
-export { Performance, performance } from "./_performance";
-export { PerformanceObserver, PerformanceObserverEntryList } from "./_observer";
+export { Performance, _Performance, performance } from "./_performance";
+
+export {
+  PerformanceObserver,
+  _PerformanceObserver,
+  PerformanceObserverEntryList,
+  _PerformanceObserverEntryList,
+} from "./_observer";
+
 export {
   PerformanceEntry,
+  _PerformanceEntry,
   PerformanceMark,
+  _PerformanceMark,
   PerformanceMeasure,
+  _PerformanceMeasure,
   PerformanceResourceTiming,
+  _PerformanceResourceTiming,
 } from "./_entry";
 
 // Not implemented:


### PR DESCRIPTION
Continuation to #213

Adding `_*` variant exports that are explicit polyfills to allow mixed usage. (important: constructor is also only possible via polyfill and not with natives)

The polyfilled `_Performance` class also now prefers `globalThis.performance.now` if available (and `timeOrigin` of instance is unchanged or 0 in worked) 

Credits to @IgorMinar for ideas in https://github.com/unjs/unenv/pull/209#issuecomment-2130393653 by 