### PR TITLE
feat(node:readline): polyfill `node:readline` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ const envConfig = env(nodeless, vercel, {});
 - [node:process](https://nodejs.org/api/process.html)  - ✅ polyfilled 83/92 exports 
 - [node:punycode](https://nodejs.org/api/punycode.html)  - 🚧 mocked using proxy 
 - [node:querystring](https://nodejs.org/api/querystring.html)  - ✅ polyfilled all exports 
-- [node:readline](https://nodejs.org/api/readline.html)  - 🚧 mocked using proxy 
-- [node:readline/promises](https://nodejs.org/api/readline.html)  - 🚧 mocked using proxy 
+- [node:readline](https://nodejs.org/api/readline.html)  - ✅ polyfilled all exports 
+- [node:readline/promises](https://nodejs.org/api/readline.html)  - ✅ polyfilled all exports 
 - [node:repl](https://nodejs.org/api/repl.html)  - 🚧 mocked using proxy 
 - [node:stream](https://nodejs.org/api/stream.html)  - ✅ polyfilled 17/37 exports 
 - [node:stream/consumers](https://nodejs.org/api/stream.html)  - ✅ polyfilled all exports 

--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -35,6 +35,8 @@ const nodeless: Preset & { alias: Map<string, string> } = {
         "perf_hooks",
         "process",
         "querystring",
+        "readline",
+        "readline/promises",
         "stream",
         "stream/promises",
         "stream/consumers",

--- a/src/runtime/node/readline/index.ts
+++ b/src/runtime/node/readline/index.ts
@@ -1,6 +1,6 @@
 // https://nodejs.org/api/readline.html#readlineclearlinestream-dir-callback
 import type readline from "node:readline";
-import noop from "src/runtime/mock/noop";
+import noop from "../../mock/noop";
 import promises from "./promises";
 import { Interface } from "./interface";
 

--- a/src/runtime/node/readline/index.ts
+++ b/src/runtime/node/readline/index.ts
@@ -1,0 +1,28 @@
+// https://nodejs.org/api/readline.html#readlineclearlinestream-dir-callback
+import type readline from "node:readline";
+import noop from "src/runtime/mock/noop";
+import promises from "./promises";
+import { Interface } from "./interface";
+
+export * as promises from "./promises";
+export { Interface } from "./interface";
+
+export const clearLine: typeof readline.clearLine = () => false;
+export const clearScreenDown: typeof readline.clearScreenDown = () => false;
+export const createInterface: typeof readline.createInterface = () =>
+  new Interface();
+export const cursorTo: typeof readline.cursorTo = () => false;
+export const emitKeypressEvents: typeof readline.emitKeypressEvents = noop;
+export const moveCursor: typeof readline.moveCursor = () => false;
+
+export default <typeof readline>{
+  Interface,
+  Readline: Interface,
+  clearLine,
+  clearScreenDown,
+  createInterface,
+  cursorTo,
+  emitKeypressEvents,
+  moveCursor,
+  promises,
+};

--- a/src/runtime/node/readline/interface.ts
+++ b/src/runtime/node/readline/interface.ts
@@ -1,0 +1,44 @@
+import type readline from "node:readline";
+import type { Abortable } from "node:events";
+import { EventEmitter } from "../events";
+import { createNotImplementedError } from "src/runtime/_internal/utils";
+
+// eslint-disable-next-line unicorn/prefer-event-target
+export class Interface extends EventEmitter implements readline.Interface {
+  terminal = false;
+  line = "";
+  cursor = 0;
+
+  getPrompt() {
+    return "";
+  }
+  setPrompt(prompt: string): void {}
+  prompt(preserveCursor?: boolean | undefined): void {}
+  question(query: string, callback: (answer: string) => void): void;
+  question(
+    query: string,
+    options: Abortable,
+    callback: (answer: string) => void,
+  ): void;
+  question(query: unknown, options: unknown, callback?: unknown): void {}
+
+  resume() {
+    return this;
+  }
+  close() {}
+  write(data: string | Buffer, key?: readline.Key | undefined): void;
+  write(data: string | Buffer | null | undefined, key: readline.Key): void;
+  write(data: unknown, key?: unknown): void {}
+  getCursorPos(): readline.CursorPos {
+    return {
+      rows: 0,
+      cols: 0,
+    };
+  }
+  pause() {
+    return this;
+  }
+  [Symbol.asyncIterator](): AsyncIterableIterator<string> {
+    throw createNotImplementedError("Interface.asyncIterator");
+  }
+}

--- a/src/runtime/node/readline/interface.ts
+++ b/src/runtime/node/readline/interface.ts
@@ -20,7 +20,9 @@ export class Interface extends EventEmitter implements readline.Interface {
     options: Abortable,
     callback: (answer: string) => void,
   ): void;
-  question(query: unknown, options: unknown, callback?: unknown): void {}
+  question(query: unknown, options: unknown, callback?: unknown): void {
+    callback && typeof callback === "function" && callback("");
+  }
 
   resume() {
     return this;
@@ -38,7 +40,8 @@ export class Interface extends EventEmitter implements readline.Interface {
   pause() {
     return this;
   }
-  [Symbol.asyncIterator](): AsyncIterableIterator<string> {
-    throw createNotImplementedError("Interface.asyncIterator");
+
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<string> {
+    yield "";
   }
 }

--- a/src/runtime/node/readline/interface.ts
+++ b/src/runtime/node/readline/interface.ts
@@ -1,7 +1,7 @@
 import type readline from "node:readline";
 import type { Abortable } from "node:events";
-import { EventEmitter } from "../events";
-import { createNotImplementedError } from "src/runtime/_internal/utils";
+import { EventEmitter } from "node:events";
+import { createNotImplementedError } from "../../_internal/utils";
 
 // eslint-disable-next-line unicorn/prefer-event-target
 export class Interface extends EventEmitter implements readline.Interface {

--- a/src/runtime/node/readline/promises/index.ts
+++ b/src/runtime/node/readline/promises/index.ts
@@ -1,0 +1,15 @@
+import type readline from "node:readline/promises";
+import { Interface } from "./interface";
+import { Readline } from "./readline";
+
+export { Interface } from "./interface";
+export { Readline } from "./readline";
+
+export const createInterface: typeof readline.createInterface = () =>
+  new Interface();
+
+export default <typeof readline>{
+  Interface,
+  Readline,
+  createInterface,
+};

--- a/src/runtime/node/readline/promises/interface.ts
+++ b/src/runtime/node/readline/promises/interface.ts
@@ -1,0 +1,11 @@
+import type readline from "node:readline/promises";
+import type { Abortable } from "node:events";
+import { Interface as _Interface } from "../interface";
+
+export class Interface extends _Interface implements readline.Interface {
+  question(query: string): Promise<string>;
+  question(query: string, options: Abortable): Promise<string>;
+  question(query: unknown, options?: unknown): Promise<string> {
+    return Promise.resolve("");
+  }
+}

--- a/src/runtime/node/readline/promises/readline.ts
+++ b/src/runtime/node/readline/promises/readline.ts
@@ -1,0 +1,23 @@
+import type readline from "node:readline/promises";
+import type { Direction } from "node:readline";
+
+export class Readline implements readline.Readline {
+  clearLine(dir: Direction) {
+    return this;
+  }
+  clearScreenDown() {
+    return this;
+  }
+  commit(): Promise<void> {
+    return Promise.resolve();
+  }
+  cursorTo(x: number, y?: number | undefined) {
+    return this;
+  }
+  moveCursor(dx: number, dy: number) {
+    return this;
+  }
+  rollback() {
+    return this;
+  }
+}


### PR DESCRIPTION
Replaces the current auto-mocking of 'readline' to support destructured ESM imports and allow for functional polyfill coverage in the future.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
