### PR TITLE
feat: polyfill `node:trace_events` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ const envConfig = env(nodeless, vercel, {});
 - [node:timers](https://nodejs.org/api/timers.html)  - 🚧 mocked using proxy 
 - [node:timers/promises](https://nodejs.org/api/timers.html)  - 🚧 mocked using proxy 
 - [node:tls](https://nodejs.org/api/tls.html)  - 🚧 mocked using proxy 
-- [node:trace_events](https://nodejs.org/api/trace_events.html)  - 🚧 mocked using proxy 
+- [node:trace_events](https://nodejs.org/api/trace_events.html)  - ✅ polyfilled all exports 
 - [node:tty](https://nodejs.org/api/tty.html)  - 🚧 mocked using proxy 
 - [node:url](https://nodejs.org/api/url.html)  - ✅ polyfilled 10/12 exports 
 - [node:util](https://nodejs.org/api/util.html)  - ✅ polyfilled all exports 

--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -40,6 +40,7 @@ const nodeless: Preset & { alias: Map<string, string> } = {
         "stream/consumers",
         "stream/web",
         "string_decoder",
+        "trace_events",
         "url",
         "util",
         "util/types",

--- a/src/runtime/node/trace_events/index.ts
+++ b/src/runtime/node/trace_events/index.ts
@@ -5,7 +5,7 @@ export const createTracing: typeof trace_events.createTracing = function () {
   return new Tracing();
 };
 export const getEnabledCategories: typeof trace_events.getEnabledCategories =
-  () => undefined;
+  () => "";
 
 export default <typeof trace_events>{
   createTracing,

--- a/src/runtime/node/trace_events/index.ts
+++ b/src/runtime/node/trace_events/index.ts
@@ -1,0 +1,13 @@
+import type trace_events from "node:trace_events";
+import { Tracing } from "./tracing";
+
+export const createTracing: typeof trace_events.createTracing = function () {
+  return new Tracing();
+};
+export const getEnabledCategories: typeof trace_events.getEnabledCategories =
+  () => undefined;
+
+export default <typeof trace_events>{
+  createTracing,
+  getEnabledCategories,
+};

--- a/src/runtime/node/trace_events/tracing.ts
+++ b/src/runtime/node/trace_events/tracing.ts
@@ -1,0 +1,8 @@
+import type trace_events from "node:trace_events";
+
+export class Tracing implements trace_events.Tracing {
+  categories = "";
+  disable() {}
+  enable() {}
+  enabled = false;
+}

--- a/src/runtime/node/trace_events/tracing.ts
+++ b/src/runtime/node/trace_events/tracing.ts
@@ -2,11 +2,11 @@ import type trace_events from "node:trace_events";
 
 export class Tracing implements trace_events.Tracing {
   categories = "";
+  enabled = false;
   disable() {
     this.enabled = false;
   }
   enable() {
     this.enabled = true;
   }
-  enabled = false;
 }

--- a/src/runtime/node/trace_events/tracing.ts
+++ b/src/runtime/node/trace_events/tracing.ts
@@ -2,7 +2,11 @@ import type trace_events from "node:trace_events";
 
 export class Tracing implements trace_events.Tracing {
   categories = "";
-  disable() {}
-  enable() {}
+  disable() {
+    this.enabled = false;
+  }
+  enable() {
+    this.enabled = true;
+  }
   enabled = false;
 }


### PR DESCRIPTION
Replaces the current auto-mocking of `trace_events` to support destructured ESM imports and allow for functional polyfill coverage in the future.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
