### PR TITLE
feat(node:v8): polyfill `node:v8` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ const envConfig = env(nodeless, vercel, {});
 - [node:url](https://nodejs.org/api/url.html)  - ✅ polyfilled 10/12 exports 
 - [node:util](https://nodejs.org/api/util.html)  - ✅ polyfilled all exports 
 - [node:util/types](https://nodejs.org/api/util.html)  - ✅ polyfilled all exports 
-- [node:v8](https://nodejs.org/api/v8.html)  - 🚧 mocked using proxy 
+- [node:v8](https://nodejs.org/api/v8.html)  - ✅ polyfilled 19/20 exports 
 - [node:vm](https://nodejs.org/api/vm.html)  - 🚧 mocked using proxy 
 - [node:wasi](https://nodejs.org/api/wasi.html)  - 🚧 mocked using proxy 
 - [node:worker_threads](https://nodejs.org/api/worker_threads.html)  - 🚧 mocked using proxy 

--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -43,6 +43,7 @@ const nodeless: Preset & { alias: Map<string, string> } = {
         "url",
         "util",
         "util/types",
+        "v8",
       ].map((m) => [m, `unenv/runtime/node/${m}/index`]),
     ),
 

--- a/src/runtime/node/v8/deserializer.ts
+++ b/src/runtime/node/v8/deserializer.ts
@@ -1,0 +1,26 @@
+import type v8 from "node:v8";
+
+export class Deserializer implements v8.Deserializer {
+  readHeader() {
+    return false;
+  }
+  readValue() {}
+  transferArrayBuffer(id: number, arrayBuffer: ArrayBuffer) {}
+  getWireFormatVersion() {
+    return 0;
+  }
+  readUint32(): number {
+    return 0;
+  }
+  readUint64(): [number, number] {
+    return [0, 0];
+  }
+  readDouble(): number {
+    return 0;
+  }
+  readRawBytes(length: number): Buffer {
+    return Buffer.from("");
+  }
+}
+
+export class DefaultDeserializer extends Deserializer {}

--- a/src/runtime/node/v8/index.ts
+++ b/src/runtime/node/v8/index.ts
@@ -1,0 +1,113 @@
+import noop from "../../mock/noop";
+import type v8 from "node:v8";
+import { Readable } from "node:stream";
+import { Deserializer, DefaultDeserializer } from "./deserializer";
+import { Serializer, DefaultSerializer } from "./serializer";
+import { GCProfiler } from "./profiler";
+
+export { Deserializer, DefaultDeserializer } from "./deserializer";
+export { Serializer, DefaultSerializer } from "./serializer";
+export { GCProfiler } from "./profiler";
+
+const getMockHeapSpaceStats = (name: string) => ({
+  space_name: name,
+  space_size: 0,
+  space_used_size: 0,
+  space_available_size: 0,
+  physical_space_size: 0,
+});
+
+export const cachedDataVersionTag: typeof v8.cachedDataVersionTag = () => 0;
+export const deserialize: typeof v8.deserialize = noop;
+export const getHeapCodeStatistics: typeof v8.getHeapCodeStatistics = () => ({
+  code_and_metadata_size: 0,
+  bytecode_and_metadata_size: 0,
+  external_script_source_size: 0,
+  cpu_profiler_metadata_size: 0,
+});
+export const getHeapSpaceStatistics: typeof v8.getHeapSpaceStatistics = () =>
+  [
+    "read_only_space",
+    "new_space",
+    "old_space",
+    "code_space",
+    "map_space",
+    "large_object_space",
+    "code_large_object_space",
+    "new_large_object_space",
+  ].map((space) => getMockHeapSpaceStats(space));
+
+export const getHeapStatistics: typeof v8.getHeapStatistics = () => ({
+  total_heap_size: 0,
+  total_heap_size_executable: 0,
+  total_physical_size: 0,
+  total_available_size: 0,
+  used_heap_size: 0,
+  heap_size_limit: 0,
+  malloced_memory: 0,
+  peak_malloced_memory: 0,
+  does_zap_garbage: 0,
+  number_of_native_contexts: 0,
+  number_of_detached_contexts: 0,
+  total_global_handles_size: 0,
+  used_global_handles_size: 0,
+  external_memory: 0,
+});
+
+export const getHeapSnapshot: typeof v8.getHeapSnapshot = () => {
+  return Readable.from(`{
+    snapshot: {},
+    nodes: [],
+    edges: [],
+    trace_function_infos: [],
+    trace_tree: [],
+    samples: [],
+    locations: [],
+    strings: [],
+  }`);
+};
+
+export const promiseHooks: typeof v8.promiseHooks = {
+  onInit: () => noop,
+  onSettled: () => noop,
+  onBefore: () => noop,
+  onAfter: () => noop,
+  createHook: () => noop,
+};
+
+export const serialize: typeof v8.serialize = (value: any) =>
+  Buffer.from(value);
+export const setFlagsFromString: typeof v8.setFlagsFromString = noop;
+export const setHeapSnapshotNearHeapLimit: typeof v8.setHeapSnapshotNearHeapLimit =
+  noop;
+export const startupSnapshot: typeof v8.startupSnapshot = {
+  addDeserializeCallback: noop,
+  addSerializeCallback: noop,
+  setDeserializeMainFunction: noop,
+  isBuildingSnapshot: () => false,
+};
+export const stopCoverage: typeof v8.stopCoverage = noop;
+export const takeCoverage: typeof v8.takeCoverage = noop;
+export const writeHeapSnapshot: typeof v8.writeHeapSnapshot = () => "";
+
+export default <typeof v8>{
+  DefaultDeserializer,
+  Deserializer,
+  GCProfiler,
+  DefaultSerializer,
+  Serializer,
+  cachedDataVersionTag,
+  deserialize,
+  getHeapCodeStatistics,
+  getHeapSnapshot,
+  getHeapSpaceStatistics,
+  getHeapStatistics,
+  promiseHooks,
+  serialize,
+  setFlagsFromString,
+  setHeapSnapshotNearHeapLimit,
+  startupSnapshot,
+  stopCoverage,
+  takeCoverage,
+  writeHeapSnapshot,
+};

--- a/src/runtime/node/v8/profiler.ts
+++ b/src/runtime/node/v8/profiler.ts
@@ -1,0 +1,13 @@
+import type v8 from "node:v8";
+
+export class GCProfiler implements v8.GCProfiler {
+  start() {}
+  stop() {
+    return {
+      version: 1,
+      startTime: 0,
+      endTime: 0,
+      statistics: [],
+    };
+  }
+}

--- a/src/runtime/node/v8/serializer.ts
+++ b/src/runtime/node/v8/serializer.ts
@@ -1,0 +1,18 @@
+import type v8 from "node:v8";
+
+export class Serializer implements v8.Serializer {
+  writeHeader() {}
+  writeValue(val: any) {
+    return false;
+  }
+  releaseBuffer(): Buffer {
+    return Buffer.from("");
+  }
+  transferArrayBuffer(id: number, arrayBuffer: ArrayBuffer) {}
+  writeDouble(value: number) {}
+  writeUint32(value: number) {}
+  writeUint64(hi: number, lo: number) {}
+  writeRawBytes(buffer: NodeJS.TypedArray) {}
+}
+
+export class DefaultSerializer extends Serializer {}


### PR DESCRIPTION
Replaces the current auto-mocking of `v8` to support destructured ESM imports and allow for functional polyfill coverage in the future.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
