### PR TITLE
feat(node:dns): export promises api from dns module

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ const envConfig = env(nodeless, vercel, {});
 - [node:path/win32](https://nodejs.org/api/path.html)  - 🚧 mocked using proxy 
 - [node:perf_hooks](https://nodejs.org/api/perf_hooks.html)  - ✅ polyfilled 9/11 exports 
 - [node:process](https://nodejs.org/api/process.html)  - ✅ polyfilled 83/92 exports 
-- [node:punycode](https://nodejs.org/api/punycode.html)  - 🚧 mocked using proxy 
+- [node:punycode](https://nodejs.org/api/punycode.html)  - ✅ polyfilled all exports 
 - [node:querystring](https://nodejs.org/api/querystring.html)  - ✅ polyfilled all exports 
 - [node:readline](https://nodejs.org/api/readline.html)  - ✅ polyfilled all exports 
 - [node:readline/promises](https://nodejs.org/api/readline.html)  - ✅ polyfilled all exports 

--- a/src/runtime/node/dns/index.ts
+++ b/src/runtime/node/dns/index.ts
@@ -2,9 +2,11 @@ import noop from "../../mock/noop";
 import mock from "../../mock/proxy";
 import { notImplemented, notImplementedAsync } from "../../_internal/utils";
 import type dns from "node:dns";
-import * as constants from "./constants";
 import promises from "./promises";
+import * as constants from "./constants";
+
 export * from "./constants";
+export * as promises from "./promises";
 
 export const Resolver: typeof dns.Resolver =
   mock.__createMock__("dns.Resolver");


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Forgot to re-export `promises` when implementing `node:dns` module.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
