### PR TITLE
feat: support `inject` with `false` values to  override injections

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -24,11 +24,14 @@ export function env(...presets: Preset[]): Environment {
     // Inject
     if (preset.inject) {
       for (const global in preset.inject) {
-        if (Array.isArray(preset.inject[global])) {
-          const [id, ...path] = preset.inject[global];
+        const globalValue = preset.inject[global];
+        if (Array.isArray(globalValue)) {
+          const [id, ...path] = globalValue;
           _env.inject[global] = [id, ...path];
+        } else if (globalValue === null) {
+          delete _env.inject[global];
         } else {
-          _env.inject[global] = preset.inject[global];
+          _env.inject[global] = globalValue;
         }
       }
     }

--- a/src/env.ts
+++ b/src/env.ts
@@ -28,7 +28,7 @@ export function env(...presets: Preset[]): Environment {
         if (Array.isArray(globalValue)) {
           const [id, ...path] = globalValue;
           _env.inject[global] = [id, ...path];
-        } else if (globalValue === null) {
+        } else if (globalValue === false) {
           delete _env.inject[global];
         } else {
           _env.inject[global] = globalValue;

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -54,8 +54,8 @@ const cloudflarePreset: Preset = {
   inject: {
     // workerd already defines `global` and `Buffer`
     // override the previous presets so that we use the native implementation
-    global: null,
-    Buffer: null,
+    global: false,
+    Buffer: false,
   },
   polyfill: [],
   external: [

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -51,7 +51,12 @@ const cloudflarePreset: Preset = {
       ]),
     ),
   },
-  inject: {},
+  inject: {
+    // workerd already defines `global` and `Buffer`
+    // override the previous presets so that we use the native implementation
+    global: null,
+    Buffer: null,
+  },
   polyfill: [],
   external: [
     ...cloudflareNodeCompatModules.map((p) => `${p}`),

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface Environment {
 export interface Preset {
   alias?: Environment["alias"];
   // inject's value is nullable to support overrides/subtraction
-  inject?: { [key: string]: string | string[] | null };
+  inject?: { [key: string]: string | string[] | false };
   polyfill?: Environment["polyfill"];
   external?: Environment["external"];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,4 +5,10 @@ export interface Environment {
   external: string[];
 }
 
-export interface Preset extends Partial<Environment> {}
+export interface Preset {
+  alias?: Environment["alias"];
+  // inject's value is nullable to support overrides/subtraction
+  inject?: { [key: string]: string | string[] | null };
+  polyfill?: Environment["polyfill"];
+  external?: Environment["external"];
+}


### PR DESCRIPTION
Sometimes an environment might want to undo any kind of inject configuration provided by the previous preset, because this environment guaratees that an API is provided natively and doesn't need to be supported via injection.

An example is Cloudflare's workerd, which natively support Blob and global when the nodejs_compat flag is turned on.
