### PR TITLE
fix: add default export for `polyfill/process`

### DIFF
--- a/src/runtime/polyfill/process.ts
+++ b/src/runtime/polyfill/process.ts
@@ -6,3 +6,5 @@ Object.assign(globalThis.process, {
   ...unenvProcess,
   ...globalThis.process,
 }) satisfies typeof nodeProcess;
+
+export default globalThis.process;


### PR DESCRIPTION
Fixes #260 (considering wrangler dep bumps to the latest nightly version and we don't have hoisting issue)

This PR adds back default export for `polyfill/process.ts` entry, improving its compatibility.