### PR TITLE
chore: run node coverage with native esm

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 20
           cache: "pnpm"
       - run: pnpm install
+      - run: pnpm build
       - name: Fix lint issues
         run: pnpm run lint:fix
       - uses: autofix-ci/action@ea32e3a12414e6d3183163c3424a7d7a8631ad84

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
           node-version: 20
           cache: "pnpm"
       - run: pnpm install
-      - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm build
+      - run: pnpm lint
       # - run: pnpm vitest --coverage
       # - uses: codecov/codecov-action@v3
       - name: nightly release

--- a/automd.config.mjs
+++ b/automd.config.mjs
@@ -4,7 +4,7 @@ export default {
     nodeCoverage: {
       name: "node-coverage",
       async generate(ctx) {
-        const { makeCoverage } = await import("./test/node-coverage.ts");
+        const { makeCoverage } = await import("./test/node-coverage.mjs");
         const coverage = await makeCoverage();
         const contents = coverage
           .map((module) => {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "release": "pnpm test && changelogen --release && pnpm publish && git push --follow-tags",
     "test": "pnpm lint && pnpm typecheck",
     "test:deno": "NODE_NO_WARNINGS=1 pnpm jiti test/deno.ts",
-    "test:node": "jiti test/node-coverage.ts",
+    "test:node": "node test/node-coverage.mjs",
     "test:cf": "pnpm jiti test/cloudflare.ts",
     "test:vc": "pnpm jiti test/vercel.ts",
     "typecheck": "tsc --noEmit"

--- a/test/node-coverage.mjs
+++ b/test/node-coverage.mjs
@@ -1,0 +1,74 @@
+import { builtinModules } from "node:module";
+import { colorize } from "consola/utils";
+
+export async function makeCoverage() {
+  const modulesCoverage = [];
+  for (const module of builtinModules) {
+    if (module.startsWith("_")) {
+      continue;
+    }
+    try {
+      const nodeMod = await import(`node:${module}`);
+      const unenvMod = await import(`../runtime/node/${module}/index.mjs`);
+      const supportedExports = [];
+      const unsupportedExports = [];
+      for (const exportName in nodeMod) {
+        if (exportName in (unenvMod || {})) {
+          supportedExports.push(exportName);
+        } else {
+          unsupportedExports.push(exportName);
+        }
+      }
+      modulesCoverage.push({
+        name: module,
+        supportedExports,
+        unsupportedExports,
+      });
+    } catch (error) {
+      if (
+        error.code !== "ERR_MODULE_NOT_FOUND" &&
+        error.code !== "MODULE_NOT_FOUND"
+      ) {
+        throw error;
+      }
+      modulesCoverage.push({
+        name: module,
+        supportedExports: [],
+        unsupportedExports: [],
+      });
+    }
+  }
+  return modulesCoverage;
+}
+
+async function printCoverage() {
+  const modulesCoverage = await makeCoverage();
+  for (const module of modulesCoverage) {
+    const supported = module.supportedExports.length;
+    const unsupported = module.unsupportedExports.length;
+    const all = supported + module.unsupportedExports.length;
+    const status =
+      supported === 0
+        ? colorize("bgRed", " MOCK ")
+        : colorize(
+            unsupported ? "bgYellow" : "bgGreen",
+            ` ${supported}/${all} `,
+          );
+    const missingNames =
+      unsupported > 3
+        ? module.unsupportedExports.slice(0, 3).join(", ") +
+          `, and ${unsupported - 3} more...`
+        : module.unsupportedExports.join(", ");
+    const missing = missingNames
+      ? colorize("gray", ` (missing: ${missingNames})`)
+      : "";
+    console.log(
+      `${colorize(supported ? (unsupported ? "yellow" : "green") : "red", `node:${module.name}`.padEnd(25))} ${status.padEnd(20)} ${missing}`,
+    );
+  }
+}
+
+if (process.argv.some((arg) => import.meta.url.includes(arg))) {
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+  printCoverage();
+}


### PR DESCRIPTION
jiti was making some false-positives since it allows mixed esm/cjs interops.

Using native mjs, needs additional build step each time but makes tests more reliable.