### PR TITLE
refactor(node): import from `node:` for non extend usages

### DIFF
--- a/src/runtime/node/dgram/internal/socket.ts
+++ b/src/runtime/node/dgram/internal/socket.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "../../events";
+import { EventEmitter } from "node:events";
 import type net from "node:net";
 import type dgram from "node:dgram";
 

--- a/src/runtime/node/domain/internal/domain.ts
+++ b/src/runtime/node/domain/internal/domain.ts
@@ -1,5 +1,5 @@
 import { createNotImplementedError } from "../../../_internal/utils";
-import { EventEmitter } from "../../events";
+import { EventEmitter } from "node:events";
 import type domain from "node:domain";
 
 export class Domain extends EventEmitter implements domain.Domain {

--- a/src/runtime/node/http/internal/request.ts
+++ b/src/runtime/node/http/internal/request.ts
@@ -1,5 +1,5 @@
 import type http from "node:http";
-import { Socket } from "../../net";
+import { Socket } from "node:net";
 import { Readable } from "../../stream/internal/readable";
 import { rawHeaders } from "../../../_internal/utils";
 

--- a/src/runtime/node/http/internal/response.ts
+++ b/src/runtime/node/http/internal/response.ts
@@ -1,6 +1,6 @@
 import type http from "node:http";
 import type { Socket } from "node:net";
-import { Callback, HeadersObject } from "../../../_internal/types";
+import { Callback } from "../../../_internal/types";
 import { Writable } from "../../stream";
 
 // Docs: https://nodejs.org/api/http.html#http_class_http_serverresponse

--- a/src/runtime/node/tls/internal/server.ts
+++ b/src/runtime/node/tls/internal/server.ts
@@ -1,6 +1,6 @@
 import type tls from "node:tls";
 import { createNotImplementedError } from "../../../_internal/utils";
-import { Server as _Server } from "node:net";
+import { Server as _Server } from "../../net";
 
 export class Server extends _Server implements tls.Server {
   addContext(hostname: string, context: tls.SecureContextOptions) {}

--- a/src/runtime/node/tls/internal/tls-socket.ts
+++ b/src/runtime/node/tls/internal/tls-socket.ts
@@ -1,5 +1,5 @@
 import type tls from "node:tls";
-import { Socket } from "node:net";
+import { Socket } from "../../net";
 import { createNotImplementedError } from "../../../_internal/utils";
 
 export class TLSSocket extends Socket implements tls.TLSSocket {

--- a/src/runtime/node/tty/internal/read-stream.ts
+++ b/src/runtime/node/tty/internal/read-stream.ts
@@ -1,5 +1,5 @@
 import type tty from "node:tty";
-import { Socket } from "node:net";
+import { Socket } from "../../net";
 
 export class ReadStream extends Socket implements tty.ReadStream {
   isRaw = false;


### PR DESCRIPTION
I have checked recent changes for usage for node modules within polyfills.

With explicit import of `node:`, we can allow hybrid polyfills.

With explicit relative import, we can allow polyfills extending each other.

This PR unifies to use `node:` with exception of polyfill classes extending each other -- other than EventEmitter : (constructors like `Readable` are imported from `node:*`)

Relative dependencies summary:

```
fetch => node/http (virtual request)
node/http => node/stream (extends polyfills)
node/net => node/stream (extends polyfills)
node/tls => node/net (extends polyfills)
node/tty => node/net (extends polyfills)
```