### PR TITLE
chore: remove extra `throw` in `createNotImplementedError`

### DIFF
--- a/src/runtime/_internal/utils.ts
+++ b/src/runtime/_internal/utils.ts
@@ -24,7 +24,7 @@ export function mergeFns(...functions: Fn[]) {
 }
 
 export function createNotImplementedError(name: string) {
-  throw new Error(`[unenv] ${name} is not implemented yet!`);
+  return new Error(`[unenv] ${name} is not implemented yet!`);
 }
 
 export function notImplemented<Fn extends (...args: any) => any>(


### PR DESCRIPTION
All current usages of `createNotImplementedError` explicitly `throw` the result. We were throwing inside util!