### PR TITLE
refactor!: remove `node-fetch-native` polyfill for node

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "consola": "^3.2.3",
     "defu": "^6.1.4",
-    "node-fetch-native": "^1.6.4",
     "ohash": "^1.1.3",
     "pathe": "^1.1.2",
     "ufo": "^1.5.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       defu:
         specifier: ^6.1.4
         version: 6.1.4
-      node-fetch-native:
-        specifier: ^1.6.4
-        version: 1.6.4
       ohash:
         specifier: ^1.1.3
         version: 1.1.3

--- a/src/presets/node.ts
+++ b/src/presets/node.ts
@@ -9,7 +9,7 @@ export default {
     "isomorphic-fetch": "unenv/runtime/mock/empty",
   },
 
-  polyfill: ["node-fetch-native/polyfill"],
+  polyfill: [],
 
   external: [...NodeBuiltinModules],
 } as Preset;

--- a/src/runtime/polyfill/fetch.node.ts
+++ b/src/runtime/polyfill/fetch.node.ts
@@ -1,1 +1,0 @@
-import "node-fetch-native/polyfill";


### PR DESCRIPTION
With node 16 being EOL, node.js does not need a polyfill anymore.