### PR TITLE
fix(node:console): optional access to `console.createTask`

### DIFF
--- a/src/runtime/node/console/index.ts
+++ b/src/runtime/node/console/index.ts
@@ -21,7 +21,7 @@ export const warn: typeof console.warn = _console?.warn ?? error;
 
 // https://developer.chrome.com/docs/devtools/console/api#createtask
 export const createTask =
-  (_console as any).createTask ?? notImplemented("console.createTask");
+  (_console as any)?.createTask ?? notImplemented("console.createTask");
 
 export const assert: typeof console.assert =
   notImplemented<typeof console.assert>("console.assert");


### PR DESCRIPTION
Just like any other access to globalThis.console, we must use safe navigation operator for `createTask`.
