### PR TITLE
feat(cloudflare): implement `node:module` as an hybrid polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,21 +145,21 @@ const envConfig = env(nodeless, vercel, {});
 - ✅ [node:dns/promises](https://nodejs.org/api/dns.html)
 - ✅ [node:domain](https://nodejs.org/api/domain.html)
 - ✅ [node:events](https://nodejs.org/api/events.html)
-- ✅ [node:fs](https://nodejs.org/api/fs.html)
-- ✅ [node:fs/promises](https://nodejs.org/api/fs.html)
-- ✅ [node:http](https://nodejs.org/api/http.html)
+- 🚧 [node:fs](https://nodejs.org/api/fs.html) <!-- missing glob, globSync exports -->
+- 🚧 [node:fs/promises](https://nodejs.org/api/fs.html) <!-- missing glob exports -->
+- 🚧 [node:http](https://nodejs.org/api/http.html) <!-- missing CloseEvent, MessageEvent, WebSocket exports -->
 - ✅ [node:http2](https://nodejs.org/api/http2.html)
 - ✅ [node:https](https://nodejs.org/api/https.html)
-- ✅ [node:inspector](https://nodejs.org/api/inspector.html)
+- 🚧 [node:inspector](https://nodejs.org/api/inspector.html) <!-- missing Network exports -->
 - 🚧 [node:inspector/promises](https://nodejs.org/api/inspector.html)
 - ✅ [node:module](https://nodejs.org/api/module.html)
 - ✅ [node:net](https://nodejs.org/api/net.html)
 - ✅ [node:os](https://nodejs.org/api/os.html)
-- ✅ [node:path](https://nodejs.org/api/path.html)
-- ✅ [node:path/posix](https://nodejs.org/api/path.html)
-- ✅ [node:path/win32](https://nodejs.org/api/path.html)
+- 🚧 [node:path](https://nodejs.org/api/path.html) <!-- missing matchesGlob exports -->
+- 🚧 [node:path/posix](https://nodejs.org/api/path.html) <!-- missing matchesGlob exports -->
+- 🚧 [node:path/win32](https://nodejs.org/api/path.html) <!-- missing matchesGlob exports -->
 - ✅ [node:perf_hooks](https://nodejs.org/api/perf_hooks.html)
-- ✅ [node:process](https://nodejs.org/api/process.html)
+- 🚧 [node:process](https://nodejs.org/api/process.html) <!-- missing finalization, getBuiltinModule exports -->
 - ✅ [node:punycode](https://nodejs.org/api/punycode.html)
 - ✅ [node:querystring](https://nodejs.org/api/querystring.html)
 - ✅ [node:readline](https://nodejs.org/api/readline.html)
@@ -171,6 +171,7 @@ const envConfig = env(nodeless, vercel, {});
 - ✅ [node:stream/web](https://nodejs.org/api/stream.html)
 - ✅ [node:string_decoder](https://nodejs.org/api/string_decoder.html)
 - ✅ [node:sys](https://nodejs.org/api/sys.html)
+- 🚧 [node:test/mock_loader](https://nodejs.org/api/test.html)
 - ✅ [node:timers](https://nodejs.org/api/timers.html)
 - ✅ [node:timers/promises](https://nodejs.org/api/timers.html)
 - ✅ [node:tls](https://nodejs.org/api/tls.html)
@@ -182,7 +183,7 @@ const envConfig = env(nodeless, vercel, {});
 - ✅ [node:v8](https://nodejs.org/api/v8.html)
 - ✅ [node:vm](https://nodejs.org/api/vm.html)
 - ✅ [node:wasi](https://nodejs.org/api/wasi.html)
-- ✅ [node:worker_threads](https://nodejs.org/api/worker_threads.html)
+- 🚧 [node:worker_threads](https://nodejs.org/api/worker_threads.html) <!-- missing postMessageToThread exports -->
 - 🚧 [node:zlib](https://nodejs.org/api/zlib.html) <!-- missing crc32 exports -->
 
 <!-- /automd -->

--- a/README.md
+++ b/README.md
@@ -145,21 +145,21 @@ const envConfig = env(nodeless, vercel, {});
 - ✅ [node:dns/promises](https://nodejs.org/api/dns.html)
 - ✅ [node:domain](https://nodejs.org/api/domain.html)
 - ✅ [node:events](https://nodejs.org/api/events.html)
-- 🚧 [node:fs](https://nodejs.org/api/fs.html) <!-- missing glob, globSync exports -->
-- 🚧 [node:fs/promises](https://nodejs.org/api/fs.html) <!-- missing glob exports -->
-- 🚧 [node:http](https://nodejs.org/api/http.html) <!-- missing CloseEvent, MessageEvent, WebSocket exports -->
+- ✅ [node:fs](https://nodejs.org/api/fs.html)
+- ✅ [node:fs/promises](https://nodejs.org/api/fs.html)
+- ✅ [node:http](https://nodejs.org/api/http.html)
 - ✅ [node:http2](https://nodejs.org/api/http2.html)
 - ✅ [node:https](https://nodejs.org/api/https.html)
-- 🚧 [node:inspector](https://nodejs.org/api/inspector.html) <!-- missing Network exports -->
+- ✅ [node:inspector](https://nodejs.org/api/inspector.html)
 - 🚧 [node:inspector/promises](https://nodejs.org/api/inspector.html)
 - ✅ [node:module](https://nodejs.org/api/module.html)
 - ✅ [node:net](https://nodejs.org/api/net.html)
 - ✅ [node:os](https://nodejs.org/api/os.html)
-- 🚧 [node:path](https://nodejs.org/api/path.html) <!-- missing matchesGlob exports -->
-- 🚧 [node:path/posix](https://nodejs.org/api/path.html) <!-- missing matchesGlob exports -->
-- 🚧 [node:path/win32](https://nodejs.org/api/path.html) <!-- missing matchesGlob exports -->
+- ✅ [node:path](https://nodejs.org/api/path.html)
+- ✅ [node:path/posix](https://nodejs.org/api/path.html)
+- ✅ [node:path/win32](https://nodejs.org/api/path.html)
 - ✅ [node:perf_hooks](https://nodejs.org/api/perf_hooks.html)
-- 🚧 [node:process](https://nodejs.org/api/process.html) <!-- missing finalization, getBuiltinModule exports -->
+- ✅ [node:process](https://nodejs.org/api/process.html)
 - ✅ [node:punycode](https://nodejs.org/api/punycode.html)
 - ✅ [node:querystring](https://nodejs.org/api/querystring.html)
 - ✅ [node:readline](https://nodejs.org/api/readline.html)
@@ -171,7 +171,6 @@ const envConfig = env(nodeless, vercel, {});
 - ✅ [node:stream/web](https://nodejs.org/api/stream.html)
 - ✅ [node:string_decoder](https://nodejs.org/api/string_decoder.html)
 - ✅ [node:sys](https://nodejs.org/api/sys.html)
-- 🚧 [node:test/mock_loader](https://nodejs.org/api/test.html)
 - ✅ [node:timers](https://nodejs.org/api/timers.html)
 - ✅ [node:timers/promises](https://nodejs.org/api/timers.html)
 - ✅ [node:tls](https://nodejs.org/api/tls.html)
@@ -183,7 +182,7 @@ const envConfig = env(nodeless, vercel, {});
 - ✅ [node:v8](https://nodejs.org/api/v8.html)
 - ✅ [node:vm](https://nodejs.org/api/vm.html)
 - ✅ [node:wasi](https://nodejs.org/api/wasi.html)
-- 🚧 [node:worker_threads](https://nodejs.org/api/worker_threads.html) <!-- missing postMessageToThread exports -->
+- ✅ [node:worker_threads](https://nodejs.org/api/worker_threads.html)
 - 🚧 [node:zlib](https://nodejs.org/api/zlib.html) <!-- missing crc32 exports -->
 
 <!-- /automd -->

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -26,6 +26,7 @@ const hybridNodeCompatModules = [
   "console",
   "buffer",
   "crypto",
+  "module",
   "process",
   "util",
   "util/types",

--- a/src/runtime/node/module/$cloudflare.ts
+++ b/src/runtime/node/module/$cloudflare.ts
@@ -1,0 +1,88 @@
+// https://nodejs.org/api/module.html
+import type nodeModule from "node:module";
+
+export {
+  Module,
+  SourceMap,
+  _cache,
+  _extensions,
+  _debug,
+  _pathCache,
+  _findPath,
+  _initPaths,
+  _load,
+  _nodeModulePaths,
+  _preloadModules,
+  _resolveFilename,
+  _resolveLookupPaths,
+} from "./index";
+
+import {
+  Module,
+  SourceMap,
+  _cache,
+  _extensions,
+  _debug,
+  _pathCache,
+  _findPath,
+  _initPaths,
+  _load,
+  _nodeModulePaths,
+  _preloadModules,
+  _resolveFilename,
+  _resolveLookupPaths,
+  builtinModules as unenvBuiltinModules,
+  createRequire as unenvCreateRequire,
+  findSourceMap as unenvFindSourceMap,
+  globalPaths as unenvGlobalPaths,
+  isBuiltin as unenvIsBuiltin,
+  register as unenvRegister,
+  runMain as unenvRunMain,
+  syncBuiltinESMExports as unenvSyncBuiltinESMExports,
+  wrap as unenvWrap,
+} from "./index";
+
+const workerdModule = process.getBuiltinModule("node:module");
+
+const resolvedExports = {
+  builtinModules: workerdModule?.builtinModules ?? unenvBuiltinModules,
+  createRequire: { ...unenvCreateRequire, ...workerdModule?.createRequire },
+  findSourceMap: unenvFindSourceMap,
+  globalPaths: unenvGlobalPaths,
+  isBuiltin: workerdModule?.isBuiltin ?? unenvIsBuiltin,
+  register: unenvRegister,
+  runMain: unenvRunMain,
+  syncBuiltinESMExports: unenvSyncBuiltinESMExports,
+  wrap: unenvWrap,
+} satisfies nodeModule;
+
+export const {
+  builtinModules,
+  createRequire,
+  findSourceMap,
+  globalPaths,
+  isBuiltin,
+  register,
+  runMain,
+  syncBuiltinESMExports,
+  wrap,
+} = resolvedExports;
+
+// polyfill missing module API in workerd, while preserving its identity
+Object.assign(resolvedExports, {
+  Module,
+  SourceMap,
+  _cache,
+  _extensions,
+  _debug,
+  _pathCache,
+  _findPath,
+  _initPaths,
+  _load,
+  _nodeModulePaths,
+  _preloadModules,
+  _resolveFilename,
+  _resolveLookupPaths,
+});
+
+export default resolvedExports;

--- a/src/runtime/node/module/$cloudflare.ts
+++ b/src/runtime/node/module/$cloudflare.ts
@@ -61,16 +61,25 @@ export function createRequire(
     return requirePolyfill;
   }
 
-  const requireFn = workerdModule.createRequire(file) as any;
+  const requireFn = workerdModule.createRequire(file) as ReturnType<
+    typeof unenvCreateRequire
+  >;
 
   // Patch properties missing from `workerd`.
-  for (const key of ["resolve", "cache", "extensions", "main"] as const) {
-    if (!(key in requireFn)) {
-      requireFn[key] = requirePolyfill[key];
-    }
+  if (!requireFn.resolve) {
+    requireFn.resolve = requirePolyfill.resolve;
+  }
+  if (!requireFn.cache) {
+    requireFn.cache = requirePolyfill.cache;
+  }
+  if (!requireFn.extensions) {
+    requireFn.extensions = requirePolyfill.extensions;
+  }
+  if (!requireFn.main) {
+    requireFn.main = requirePolyfill.main;
   }
 
-  return requireFn as ReturnType<typeof unenvCreateRequire>;
+  return requireFn;
 }
 
 export default {

--- a/src/runtime/node/module/$cloudflare.ts
+++ b/src/runtime/node/module/$cloudflare.ts
@@ -86,4 +86,3 @@ export default {
   syncBuiltinESMExports,
   wrap,
 };
-

--- a/src/runtime/node/module/$cloudflare.ts
+++ b/src/runtime/node/module/$cloudflare.ts
@@ -64,9 +64,9 @@ export function createRequire(
   const requireFn = workerdModule.createRequire(file) as any;
 
   // Patch properties missing from `workerd`.
-  for (const [key, value] of Object.entries(requirePolyfill)) {
+  for (const key of ["resolve", "cache", "extensions", "main"] as const) {
     if (!(key in requireFn)) {
-      requireFn[key] = value;
+      requireFn[key] = requirePolyfill[key];
     }
   }
 

--- a/src/runtime/node/module/$cloudflare.ts
+++ b/src/runtime/node/module/$cloudflare.ts
@@ -61,16 +61,16 @@ export function createRequire(
     return requirePolyfill;
   }
 
-  const require = workerdModule.createRequire(file) as any;
+  const requireFn = workerdModule.createRequire(file) as any;
 
   // Patch properties missing from `workerd`.
   for (const [key, value] of Object.entries(requirePolyfill)) {
-    if (!(key in require)) {
-      require[key] = value;
+    if (!(key in requireFn)) {
+      requireFn[key] = value;
     }
   }
 
-  return require as ReturnType<typeof unenvCreateRequire>;
+  return requireFn as ReturnType<typeof unenvCreateRequire>;
 }
 
 export default {

--- a/src/runtime/node/module/$cloudflare.ts
+++ b/src/runtime/node/module/$cloudflare.ts
@@ -15,6 +15,14 @@ export {
   _preloadModules,
   _resolveFilename,
   _resolveLookupPaths,
+  builtinModules,
+  findSourceMap,
+  globalPaths,
+  isBuiltin,
+  register,
+  runMain,
+  syncBuiltinESMExports,
+  wrap,
 } from "./index";
 
 import {
@@ -31,34 +39,8 @@ import {
   _preloadModules,
   _resolveFilename,
   _resolveLookupPaths,
-  builtinModules as unenvBuiltinModules,
-  createRequire as unenvCreateRequire,
-  findSourceMap as unenvFindSourceMap,
-  globalPaths as unenvGlobalPaths,
-  isBuiltin as unenvIsBuiltin,
-  register as unenvRegister,
-  runMain as unenvRunMain,
-  syncBuiltinESMExports as unenvSyncBuiltinESMExports,
-  wrap as unenvWrap,
-} from "./index";
-
-const workerdModule = process.getBuiltinModule("node:module");
-
-const resolvedExports = {
-  builtinModules: workerdModule?.builtinModules ?? unenvBuiltinModules,
-  createRequire: { ...unenvCreateRequire, ...workerdModule?.createRequire },
-  findSourceMap: unenvFindSourceMap,
-  globalPaths: unenvGlobalPaths,
-  isBuiltin: workerdModule?.isBuiltin ?? unenvIsBuiltin,
-  register: unenvRegister,
-  runMain: unenvRunMain,
-  syncBuiltinESMExports: unenvSyncBuiltinESMExports,
-  wrap: unenvWrap,
-} satisfies nodeModule;
-
-export const {
   builtinModules,
-  createRequire,
+  createRequire as unenvCreateRequire,
   findSourceMap,
   globalPaths,
   isBuiltin,
@@ -66,10 +48,21 @@ export const {
   runMain,
   syncBuiltinESMExports,
   wrap,
-} = resolvedExports;
+} from "./index";
 
-// polyfill missing module API in workerd, while preserving its identity
-Object.assign(resolvedExports, {
+const workerdModule = process.getBuiltinModule("node:module");
+
+const createRequire: any = workerdModule?.createRequire ?? unenvCreateRequire;
+
+if (workerdModule?.createRequire === undefined) {
+  for (const [key, value] of Object.entries(unenvCreateRequire)) {
+    createRequire[key] = value;
+  }
+}
+
+export { createRequire };
+
+export default {
   Module,
   SourceMap,
   _cache,
@@ -83,6 +76,14 @@ Object.assign(resolvedExports, {
   _preloadModules,
   _resolveFilename,
   _resolveLookupPaths,
-});
+  builtinModules,
+  createRequire,
+  findSourceMap,
+  globalPaths,
+  isBuiltin,
+  register,
+  runMain,
+  syncBuiltinESMExports,
+  wrap,
+};
 
-export default resolvedExports;


### PR DESCRIPTION
Related `workerd` PR: https://github.com/cloudflare/workerd/pull/2636

This PR changes `module` to be an hybrid polyfill and use the workerd available method implementations.

Is there anything else to change/update?

Thanks!

/cc @pi0 