### PR TITLE
feat(cloudflare): use unenv implementation of `setImmediate` for `node:timers`

### DIFF
--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -28,6 +28,7 @@ const hybridNodeCompatModules = [
   "crypto",
   "module",
   "process",
+  "timers",
   "util",
   "util/types",
 ];

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -67,6 +67,8 @@ const cloudflarePreset: Preset = {
     global: false,
     console: "unenv/runtime/node/console/$cloudflare",
     process: "unenv/runtime/node/process/$cloudflare",
+    setImmediate: ["unenv/runtime/node/timers/$cloudflare", "setImmediate"],
+    clearImmediate: ["unenv/runtime/node/timers/$cloudflare", "clearImmediate"],
   },
   polyfill: [],
   external: [

--- a/src/runtime/node/timers/$cloudflare.ts
+++ b/src/runtime/node/timers/$cloudflare.ts
@@ -1,0 +1,52 @@
+import type timers from "node:timers";
+
+export {
+  _unrefActive,
+  active,
+  clearInterval,
+  clearTimeout,
+  enroll,
+  promises,
+  setInterval,
+  setTimeout,
+  unenroll,
+} from "./index";
+
+export {
+  setImmediateFallback as setImmediate,
+  clearImmediateFallback as clearImmediate,
+} from "./internal/set-immediate";
+
+import {
+  _unrefActive,
+  active,
+  clearInterval,
+  clearTimeout,
+  enroll,
+  promises,
+  setInterval,
+  setTimeout,
+  unenroll,
+} from "./index";
+
+import {
+  setImmediateFallback as setImmediate,
+  clearImmediateFallback as clearImmediate,
+} from "./internal/set-immediate";
+
+globalThis.setImmediate = setImmediate;
+globalThis.clearImmediate = clearImmediate;
+
+export default <typeof timers>{
+  _unrefActive,
+  active,
+  clearImmediate,
+  clearInterval,
+  clearTimeout,
+  enroll,
+  promises,
+  setImmediate,
+  setInterval,
+  setTimeout,
+  unenroll,
+};

--- a/src/runtime/node/timers/$cloudflare.ts
+++ b/src/runtime/node/timers/$cloudflare.ts
@@ -10,6 +10,10 @@ import {
 import { setIntervalFallback } from "./internal/set-interval";
 
 // Always use the polyfill rather than the worked implementation.
+//
+// NOTE:
+// `setImmediate` and `clearImmediate` must be function (re)exports.
+// `export const setImmediate = ...` might cause esbuild to generate invalid code.
 export {
   setImmediateFallback as setImmediate,
   clearImmediateFallback as clearImmediate,

--- a/src/runtime/node/timers/$cloudflare.ts
+++ b/src/runtime/node/timers/$cloudflare.ts
@@ -1,41 +1,36 @@
+import { notImplemented } from "../../_internal/utils";
+import noop from "../../mock/noop";
 import type timers from "node:timers";
+import promises from "./promises";
+import { setTimeoutFallback } from "./internal/set-timeout";
+import {
+  setImmediateFallback as setImmediate,
+  clearImmediateFallback as clearImmediate,
+} from "./internal/set-immediate";
+import { setIntervalFallback } from "./internal/set-interval";
 
-export {
-  _unrefActive,
-  active,
-  clearInterval,
-  clearTimeout,
-  enroll,
-  promises,
-  setInterval,
-  setTimeout,
-  unenroll,
-} from "./index";
-
+// Always use the polyfill rather than the worked implementation.
 export {
   setImmediateFallback as setImmediate,
   clearImmediateFallback as clearImmediate,
 } from "./internal/set-immediate";
 
-import {
-  _unrefActive,
-  active,
-  clearInterval,
-  clearTimeout,
-  enroll,
-  promises,
-  setInterval,
-  setTimeout,
-  unenroll,
-} from "./index";
+export * as promises from "./promises";
 
-import {
-  setImmediateFallback as setImmediate,
-  clearImmediateFallback as clearImmediate,
-} from "./internal/set-immediate";
+export const clearInterval: typeof timers.clearInterval =
+  globalThis.clearInterval || noop;
+export const clearTimeout: typeof timers.clearTimeout =
+  globalThis.clearTimeout || noop;
 
-globalThis.setImmediate = setImmediate;
-globalThis.clearImmediate = clearImmediate;
+export const setTimeout: typeof timers.setTimeout =
+  globalThis.setTimeout || setTimeoutFallback;
+export const setInterval: typeof timers.setInterval =
+  globalThis.setInterval || setIntervalFallback;
+
+export const active = notImplemented("timers.active");
+export const _unrefActive = notImplemented("timers._unrefActive");
+export const enroll = notImplemented("timers.enroll");
+export const unenroll = notImplemented("timers.unenroll");
 
 export default <typeof timers>{
   _unrefActive,

--- a/src/runtime/node/timers/$cloudflare.ts
+++ b/src/runtime/node/timers/$cloudflare.ts
@@ -1,13 +1,16 @@
-import { notImplemented } from "../../_internal/utils";
-import noop from "../../mock/noop";
-import type timers from "node:timers";
-import promises from "./promises";
-import { setTimeoutFallback } from "./internal/set-timeout";
-import {
-  setImmediateFallback as setImmediate,
-  clearImmediateFallback as clearImmediate,
-} from "./internal/set-immediate";
-import { setIntervalFallback } from "./internal/set-interval";
+import type nodeTimers from "node:timers";
+
+export {
+  _unrefActive,
+  active,
+  clearInterval,
+  clearTimeout,
+  enroll,
+  promises,
+  setInterval,
+  setTimeout,
+  unenroll,
+} from "./index";
 
 // Always use the polyfill rather than the worked implementation.
 //
@@ -19,24 +22,24 @@ export {
   clearImmediateFallback as clearImmediate,
 } from "./internal/set-immediate";
 
-export * as promises from "./promises";
+import {
+  _unrefActive,
+  active,
+  clearInterval,
+  clearTimeout,
+  enroll,
+  promises,
+  setInterval,
+  setTimeout,
+  unenroll,
+} from "./index";
 
-export const clearInterval: typeof timers.clearInterval =
-  globalThis.clearInterval || noop;
-export const clearTimeout: typeof timers.clearTimeout =
-  globalThis.clearTimeout || noop;
+import {
+  setImmediateFallback as setImmediate,
+  clearImmediateFallback as clearImmediate,
+} from "./internal/set-immediate";
 
-export const setTimeout: typeof timers.setTimeout =
-  globalThis.setTimeout || setTimeoutFallback;
-export const setInterval: typeof timers.setInterval =
-  globalThis.setInterval || setIntervalFallback;
-
-export const active = notImplemented("timers.active");
-export const _unrefActive = notImplemented("timers._unrefActive");
-export const enroll = notImplemented("timers.enroll");
-export const unenroll = notImplemented("timers.unenroll");
-
-export default <typeof timers>{
+export default <typeof nodeTimers>{
   _unrefActive,
   active,
   clearImmediate,

--- a/src/runtime/node/timers/index.ts
+++ b/src/runtime/node/timers/index.ts
@@ -1,4 +1,4 @@
-import { notImplemented, notImplementedAsync } from "../../_internal/utils";
+import { notImplemented } from "../../_internal/utils";
 import noop from "../../mock/noop";
 import type timers from "node:timers";
 import promises from "./promises";

--- a/src/runtime/node/timers/internal/set-immediate.ts
+++ b/src/runtime/node/timers/internal/set-immediate.ts
@@ -1,22 +1,21 @@
 import type timers from "node:timers/promises";
 import { Immediate } from "./immediate";
 
-export const setImmediateFallbackPromises: typeof timers.setImmediate =
-  function setImmediate<T = void>(value?: T): Promise<T> {
-    return new Promise((res) => {
-      res(value as T | PromiseLike<T>);
-    });
-  };
+export function setImmediateFallbackPromises<T = void>(value?: T): Promise<T> {
+  return new Promise((res) => {
+    res(value as T | PromiseLike<T>);
+  });
+}
 
-export const setImmediateFallback = function setImmediate<TArgs extends any[]>(
+export function setImmediateFallback<TArgs extends any[]>(
   callback: (...args: TArgs) => void,
   ...args: TArgs
 ): NodeJS.Immediate {
   return new Immediate(callback, args);
-};
+}
 setImmediateFallback.__promisify__ = setImmediateFallbackPromises;
 
-export const clearImmediateFallback = function clearImmediate(
+export function clearImmediateFallback(
   immediate: NodeJS.Immediate | undefined,
 ) {
   immediate?.[Symbol.dispose]();

--- a/src/runtime/node/timers/internal/set-immediate.ts
+++ b/src/runtime/node/timers/internal/set-immediate.ts
@@ -19,4 +19,4 @@ export function clearImmediateFallback(
   immediate: NodeJS.Immediate | undefined,
 ) {
   immediate?.[Symbol.dispose]();
-};
+}

--- a/src/runtime/node/timers/internal/set-immediate.ts
+++ b/src/runtime/node/timers/internal/set-immediate.ts
@@ -1,4 +1,3 @@
-import type timers from "node:timers/promises";
 import { Immediate } from "./immediate";
 
 export function setImmediateFallbackPromises<T = void>(value?: T): Promise<T> {

--- a/src/runtime/node/timers/internal/set-interval.ts
+++ b/src/runtime/node/timers/internal/set-interval.ts
@@ -1,4 +1,3 @@
-import type timers from "node:timers/promises";
 import { Timeout } from "./timeout";
 
 export async function* setIntervalFallbackPromises<T = void>(

--- a/src/runtime/node/timers/internal/set-interval.ts
+++ b/src/runtime/node/timers/internal/set-interval.ts
@@ -1,18 +1,18 @@
 import type timers from "node:timers/promises";
 import { Timeout } from "./timeout";
 
-export const setIntervalFallbackPromises: typeof timers.setInterval =
-  async function* setInterval<T = void>(
-    delay?: number,
-    value?: T,
-  ): AsyncIterable<T> {
-    yield value as T;
-  };
+export async function* setIntervalFallbackPromises<T = void>(
+  delay?: number,
+  value?: T,
+): AsyncIterable<T> {
+  yield value as T;
+}
 
 export function setIntervalFallback(
   callback: (args: void) => void,
   ms?: number,
 ): NodeJS.Timeout;
+
 export function setIntervalFallback<TArgs extends any[]>(
   callback: (...args: TArgs) => void,
   ms?: number,

--- a/src/runtime/node/timers/internal/set-interval.ts
+++ b/src/runtime/node/timers/internal/set-interval.ts
@@ -11,7 +11,6 @@ export function setIntervalFallback(
   callback: (args: void) => void,
   ms?: number,
 ): NodeJS.Timeout;
-
 export function setIntervalFallback<TArgs extends any[]>(
   callback: (...args: TArgs) => void,
   ms?: number,

--- a/src/runtime/node/timers/internal/set-timeout.ts
+++ b/src/runtime/node/timers/internal/set-timeout.ts
@@ -1,17 +1,19 @@
-import type timers from "node:timers/promises";
 import { Timeout } from "./timeout";
 
-export const setTimeoutFallbackPromises: typeof timers.setTimeout =
-  function setTimeout<T = void>(delay?: number, value?: T): Promise<T> {
-    return new Promise((res) => {
-      res(value as T | PromiseLike<T>);
-    });
-  };
+export function setTimeoutFallbackPromises<T = void>(
+  delay?: number,
+  value?: T,
+): Promise<T> {
+  return new Promise((res) => {
+    res(value as T | PromiseLike<T>);
+  });
+}
 
 export function setTimeoutFallback(
   callback: TimerHandler,
   ms?: number,
 ): NodeJS.Timeout;
+
 export function setTimeoutFallback<TArgs extends any[]>(
   callback: TimerHandler,
   ms?: number,
@@ -19,5 +21,4 @@ export function setTimeoutFallback<TArgs extends any[]>(
 ) {
   return new Timeout(callback, args);
 }
-
 setTimeoutFallback.__promisify__ = setTimeoutFallbackPromises;

--- a/src/runtime/node/timers/internal/set-timeout.ts
+++ b/src/runtime/node/timers/internal/set-timeout.ts
@@ -13,7 +13,6 @@ export function setTimeoutFallback(
   callback: TimerHandler,
   ms?: number,
 ): NodeJS.Timeout;
-
 export function setTimeoutFallback<TArgs extends any[]>(
   callback: TimerHandler,
   ms?: number,


### PR DESCRIPTION
We are exploring using unenv for `setImmediate`.
The desired behavior is run the callback in a `setTimeout(0)` instead of right away.
