### PR TITLE
feat(node:timer): implement `setImmediate` with `setTimeout`

### DIFF
--- a/src/runtime/node/timers/index.ts
+++ b/src/runtime/node/timers/index.ts
@@ -3,13 +3,16 @@ import noop from "../../mock/noop";
 import type timers from "node:timers";
 import promises from "./promises";
 import { setTimeoutFallback } from "./internal/set-timeout";
-import { setImmediateFallback } from "./internal/set-immediate";
+import {
+  setImmediateFallback,
+  clearImmediateFallback,
+} from "./internal/set-immediate";
 import { setIntervalFallback } from "./internal/set-interval";
 
 export * as promises from "./promises";
 
 export const clearImmediate: typeof timers.clearImmediate =
-  globalThis.clearImmediate || noop;
+  globalThis.clearImmediate || clearImmediateFallback;
 export const clearInterval: typeof timers.clearInterval =
   globalThis.clearInterval || noop;
 export const clearTimeout: typeof timers.clearTimeout =

--- a/src/runtime/node/timers/internal/immediate.ts
+++ b/src/runtime/node/timers/internal/immediate.ts
@@ -1,19 +1,32 @@
 export class Immediate<TArgs extends any[]> implements NodeJS.Immediate {
   _onImmediate: (...args: TArgs) => void;
+  private _timeout?: NodeJS.Timeout;
 
   constructor(callback: (...args: TArgs) => void, args: TArgs) {
     this._onImmediate = callback;
-    callback(...args);
+    if ("setTimeout" in globalThis) {
+      this._timeout = setTimeout(callback, 0, ...args);
+    } else {
+      callback(...args);
+    }
   }
 
   ref(): this {
+    this._timeout?.ref();
     return this;
   }
   unref(): this {
+    this._timeout?.unref();
     return this;
   }
+
   hasRef(): boolean {
-    return false;
+    return this._timeout?.hasRef() ?? false;
   }
-  [Symbol.dispose]() {}
+
+  [Symbol.dispose]() {
+    if ("clearTimeout" in globalThis) {
+      clearTimeout(this._timeout);
+    }
+  }
 }

--- a/src/runtime/node/timers/internal/set-immediate.ts
+++ b/src/runtime/node/timers/internal/set-immediate.ts
@@ -15,3 +15,9 @@ export const setImmediateFallback = function setImmediate<TArgs extends any[]>(
   return new Immediate(callback, args);
 };
 setImmediateFallback.__promisify__ = setImmediateFallbackPromises;
+
+export const clearImmediateFallback = function clearImmediate(
+  immediate: NodeJS.Immediate | undefined,
+) {
+  immediate?.[Symbol.dispose]();
+};


### PR DESCRIPTION
As discussed in https://github.com/unjs/unenv/pull/302 using a timeout is a more sensible behavior
