### PR TITLE
add `zlib` to cloudflare compat modules

### DIFF
--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -19,6 +19,7 @@ const cloudflareNodeCompatModules = [
   "stream/promises",
   "stream/web",
   "string_decoder",
+  "zlib",
 ];
 
 const hybridNodeCompatModules = [


### PR DESCRIPTION
`node:zlib` support just landed to workers. it will be included with the release on 09/23. we can add this to unenv as well.