### PR TITLE
fix: ensure Cloudflare webcrypto.getRandomBytes is bound to the correct this object

### DIFF
--- a/src/runtime/node/crypto/$cloudflare.ts
+++ b/src/runtime/node/crypto/$cloudflare.ts
@@ -89,7 +89,6 @@ export const {
   getDiffieHellman,
   getFips,
   getHashes,
-  getRandomValues,
   hkdf,
   hkdfSync,
   pbkdf2,
@@ -106,18 +105,21 @@ export const {
   timingSafeEqual,
 } = workerdCrypto;
 
+// Special case getRandomValues as it must be bound to the webcrypto object
+export const getRandomValues = workerdCrypto.getRandomValues.bind(
+  workerdCrypto.webcrypto,
+);
+
 export const webcrypto = {
   CryptoKey: unenvCryptoWebcrypto.CryptoKey,
-  getRandomValues: workerdCrypto.webcrypto.getRandomValues.bind(
-    workerdCrypto.webcrypto,
-  ),
-  randomUUID: randomUUID.bind(workerdCrypto.webcrypto),
-  subtle: workerdCrypto.webcrypto.subtle,
+  getRandomValues,
+  randomUUID,
+  subtle,
 } satisfies typeof nodeCrypto.webcrypto;
 
 // Node.js exposes fips only via the default export 🤷🏼‍♂️
 // so extract it separately from the other exports
-const { fips } = workerdCrypto;
+const fips = workerdCrypto.fips;
 
 // Node.js exposes createCipher, createDecipher, pseudoRandomBytes only via the default export 🤷🏼‍♂️
 // so extract it separately from the other exports


### PR DESCRIPTION
It appears that this is the only function in the webcrypto exports list that
needs to be bound to its original object.

Note that it must be bound to the `webcrypto` object even though workerd also
exports it on the `crypto` namespace directly.