### PR TITLE
feat(node/net): implement `Server` mock

### DIFF
--- a/src/runtime/node/net/index.ts
+++ b/src/runtime/node/net/index.ts
@@ -1,7 +1,12 @@
 // https://nodejs.org/api/net.html
 import type net from "node:net";
+
 import { notImplemented, notImplementedClass } from "../../_internal/utils";
+
 import { Socket, SocketAddress } from "./internal/socket";
+import { Server } from "./internal/server";
+
+export { Server } from "./internal/server";
 
 // require('node:net').Socket === require('node:net').Stream
 export { Socket, SocketAddress, Socket as Stream } from "./internal/socket";
@@ -9,8 +14,6 @@ export { Socket, SocketAddress, Socket as Stream } from "./internal/socket";
 export const createServer = notImplemented(
   "net.createServer",
 ) as typeof net.createServer;
-
-export const Server = notImplementedClass("net.Server") as typeof net.Server;
 
 export const BlockList = notImplementedClass(
   "net.BlockList",

--- a/src/runtime/node/net/internal/server.ts
+++ b/src/runtime/node/net/internal/server.ts
@@ -1,0 +1,45 @@
+import type * as net from "node:net";
+import { EventEmitter } from "node:events";
+
+// Docs: https://nodejs.org/api/net.html#net_class_net_socket
+export class Server extends EventEmitter implements net.Server {
+  readonly __unenv__ = true;
+
+  maxConnections: number = 1;
+  connections: number = 0;
+  readonly listening: boolean = false;
+
+  constructor(
+    arg1?: net.ServerOpts | ((socket: net.Socket) => void),
+    arg2?: (socket: net.Socket) => void,
+  ) {
+    super();
+  }
+
+  listen(): this {
+    return this;
+  }
+
+  close(callback?: (err?: Error) => void): this {
+    callback?.();
+    return this;
+  }
+
+  address(): net.AddressInfo | string | null {
+    return null;
+  }
+
+  getConnections(cb: (error: Error | null, count: number) => void): void {}
+
+  ref(): this {
+    return this;
+  }
+
+  unref(): this {
+    return this;
+  }
+
+  [Symbol.asyncDispose](): Promise<void> {
+    return Promise.resolve();
+  }
+}


### PR DESCRIPTION
resolves #314 (aka PI issue!)

`net.Server` (and `tls.Server` extending it) mock is implemented and extending EventEmitter to have more explicit behavior.