### PR TITLE
test: bump compatibilityDate past 2024-09-23

### DIFF
--- a/test/workerd/config.capnp
+++ b/test/workerd/config.capnp
@@ -10,7 +10,7 @@ const testsWorker :Workerd.Worker = (
   modules = [
     (name = "tests", esModule = embed "./tests.mjs")
   ],
-  compatibilityDate = "2024-09-01",
+  compatibilityDate = "2024-10-04",
   compatibilityFlags = ["nodejs_compat"],
   moduleFallback = "localhost:8888",
 );


### PR DESCRIPTION
`unenv` is used by wrangler only when the `workerd` flag `nodejs_compat_v2` is active.

And `nodejs_compat_v2` is implied by `nodejs_compat` after [2024-09-23](https://developers.cloudflare.com/workers/runtime-apis/nodejs/#get-started).

This PR bumps the `compatibilityDate` past 2024-09-23.

`2024-10-04` is the max `compatibilityDate` supported by the packaged `workerd` (=it's build date).