### PR TITLE
Revert "refactor(node/buffer): update cloudflare hybrid exports (#321)"

### DIFF
--- a/src/runtime/node/buffer/$cloudflare.ts
+++ b/src/runtime/node/buffer/$cloudflare.ts
@@ -1,41 +1,58 @@
 // https://nodejs.org/api/buffer.html
 import type nodeBuffer from "node:buffer";
 
-export { INSPECT_MAX_BYTES, resolveObjectURL } from "./index";
+export {
+  Blob,
+  File,
+  INSPECT_MAX_BYTES,
+  atob,
+  btoa,
+  isAscii,
+  isUtf8,
+  resolveObjectURL,
+  transcode,
+} from "./index";
 
-import { INSPECT_MAX_BYTES, resolveObjectURL } from "./index";
+import {
+  Blob,
+  File,
+  INSPECT_MAX_BYTES,
+  atob,
+  btoa,
+  isAscii,
+  isUtf8,
+  resolveObjectURL,
+  transcode,
+} from "./index";
 
 // @ts-ignore typings are not up to date, but this API exists, see: https://github.com/cloudflare/workerd/pull/2147
 const workerdBuffer = process.getBuiltinModule("node:buffer");
 
 // TODO: Ideally this list is not hardcoded but instead is generated when the preset is being generated in the `env()` call
 //       This generation should use information from https://github.com/cloudflare/workerd/issues/2097
-export const {
-  Blob,
-  Buffer,
-  File,
-  SlowBuffer,
-  constants,
-  isAscii,
-  isUtf8,
-  kMaxLength,
-  kStringMaxLength,
-  transcode,
-} = workerdBuffer;
+export const { Buffer, SlowBuffer, constants, kMaxLength, kStringMaxLength } =
+  workerdBuffer;
 
 export default {
-  INSPECT_MAX_BYTES,
+  /**
+   * manually unroll unenv-polyfilled-symbols to make it tree-shakeable
+   */
   Blob,
-  Buffer,
   File,
-  SlowBuffer,
+  INSPECT_MAX_BYTES,
   atob,
   btoa,
-  constants,
   isAscii,
   isUtf8,
-  kMaxLength,
-  kStringMaxLength,
   resolveObjectURL,
   transcode,
+
+  /**
+   * manually unroll workerd-polyfilled-symbols to make it tree-shakeable
+   */
+  Buffer,
+  SlowBuffer,
+  constants,
+  kMaxLength,
+  kStringMaxLength,
 } satisfies typeof nodeBuffer;

--- a/test/workerd/tests.mjs
+++ b/test/workerd/tests.mjs
@@ -30,31 +30,3 @@ export const url_parse = {
     );
   },
 };
-
-// --- node:buffer
-
-export const buffer_implements = {
-  async test() {
-    const Buffer = await import("unenv/runtime/node/buffer");
-    assert.ok(Buffer.isAscii("hello world"));
-    assert.ok(Buffer.isUtf8("Yağız"));
-    assert.strictEqual(Buffer.btoa("hello"), "aGVsbG8=");
-    assert.strictEqual(Buffer.atob("aGVsbG8="), "hello");
-    {
-      const dest = Buffer.transcode(
-        Buffer.from([
-          0x74, 0x00, 0x1b, 0x01, 0x73, 0x00, 0x74, 0x00, 0x20, 0x00, 0x15,
-          0x26,
-        ]),
-        "ucs2",
-        "utf8",
-      );
-      assert.strictEqual(
-        dest.toString(),
-        Buffer.from("těst ☕", "utf8").toString(),
-      );
-    }
-    assert.ok(new Buffer.File([], "file"));
-    assert.ok(new Buffer.Blob([]));
-  },
-};


### PR DESCRIPTION
The tests are actually [failing](https://github.com/unjs/unenv/actions/runs/11283168587/job/31382072651#:~:text=workerd/server/server,FAIL%20%5D%20tests%3Abuffer_implements)

```
workerd/server/server.c++:3851: debug: [ TEST ] tests:buffer_implements
[server] unenv/runtime/node/buffer from /tests
workerd/io/worker.c++:2065: info: uncaught exception; source = Uncaught (in promise); stack = TypeError: Failed to execute 'isAscii' on 'BufferUtil': parameter 1 is not of type 'ArrayBuffer or ArrayBufferView'.
    at Module.isAscii (node-internal:internal_buffer:1763:23)
    at Object.test (tests:39:22)
workerd/util/symbolizer.c++:158: warning: llvm-symbolizer was not found. To symbolize stack traces, install it in your $PATH or set $LLVM_SYMBOLIZER to the location of the binary. When running tests under bazel, use `--test_env=LLVM_SYMBOLIZER=<path>`.
workerd/io/io-context.c++:352: info: uncaught exception; exception = workerd/jsg/_virtual_includes/jsg/workerd/jsg/value.h:1372: failed: jsg.TypeError: Failed to execute 'isAscii' on 'BufferUtil': parameter 1 is not of type 'ArrayBuffer or ArrayBufferView'.
workerd/server/server.c++:3859: debug: [ FAIL ] tests:buffer_implements
```

The CI also needs to be fixed to reflect that

/cc @anonrig 
