### PR TITLE
chore: add cloudflare team to workerd tests codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 
 # all cloudflare files including src/preset/cloudflare.ts, **/$cloudflare.ts, etc.
 **/*cloudflare** @unjs/cloudflare
+/test/workerd/** @unjs/cloudflare


### PR DESCRIPTION
This came out of https://github.com/unjs/unenv/pull/325 which we should be able to approve and merge without @pi0  but we can't right due to the OWNERS config not being up todate.