### PR TITLE
feat(cloudflare): use querystring and url from workerd

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prettier": "^3.3.3",
     "typescript": "^5.6.3",
     "unbuild": "^2.0.0",
-    "workerd": "^1.20241018.0",
+    "workerd": "^1.20241022.0",
     "wrangler": "^3.81.0"
   },
   "packageManager": "pnpm@9.12.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.6.3)
       workerd:
-        specifier: ^1.20241018.0
+        specifier: ^1.20241022.0
         version: 1.20241022.0
       wrangler:
         specifier: ^3.81.0

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -3,7 +3,7 @@ import type { Preset } from "../types";
 // Built-in APIs provided by workerd.
 // https://developers.cloudflare.com/workers/runtime-apis/nodejs/
 // https://github.com/cloudflare/workerd/tree/main/src/node
-// Last checked: 2024-10-15
+// Last checked: 2024-10-22
 const cloudflareNodeCompatModules = [
   "_stream_duplex",
   "_stream_passthrough",
@@ -15,11 +15,13 @@ const cloudflareNodeCompatModules = [
   "diagnostics_channel",
   "events",
   "path",
+  "querystring",
   "stream",
   "stream/consumers",
   "stream/promises",
   "stream/web",
   "string_decoder",
+  "url",
   "util/types",
   "zlib",
 ];


### PR DESCRIPTION
See https://github.com/cloudflare/workerd/releases/tag/v1.20241022.0

Do not merge this until workerd uses [v1.20241022.0](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/package.json#L89)

