### PR TITLE
fix(module): return `undefined` with `findSourceMap`

### DIFF
--- a/src/runtime/node/module/index.ts
+++ b/src/runtime/node/module/index.ts
@@ -63,9 +63,15 @@ export const syncBuiltinESMExports: typeof nodeModule.syncBuiltinESMExports =
     return [];
   };
 
-export const findSourceMap = notImplemented(
-  "module.findSourceMap",
-) as typeof nodeModule.findSourceMap;
+export const findSourceMap: typeof nodeModule.findSourceMap = function (
+  path: string,
+  error?: Error,
+) {
+  // The cast is necessary because Node types wrongly set the return type to `SourceMap`.
+  // Comments on Node types say "Returns `module.SourceMap` if a source map is found, `undefined` otherwise."
+  // Returning `undefined` is the verified behavior.
+  return undefined as unknown as nodeModule.SourceMap;
+};
 
 export const wrap: typeof nodeModule.wrap = function (source) {
   return `(function (exports, require, module, __filename, __dirname) { ${source}\n});`;


### PR DESCRIPTION
The implementation returns undefined - meaning no source map found. Note that the Node typings are wrong. However it is part of the possible returned values, see https://github.com/nodejs/node/pull/44397/files. I also verified the behavior.

```bash
-> % node
Welcome to Node.js v22.11.0.
Type ".help" for more information.
> const m = require('module');
undefined
> m.findSourceMap('/not/a/file');
undefined
```

I am looking for the best way to update Node typings to reflect the actual return type.

Related to https://github.com/opennextjs/opennextjs-cloudflare/issues/135