### PR TITLE
node-import

### DIFF
--- a/src/runtime/node/http/internal/request.ts
+++ b/src/runtime/node/http/internal/request.ts
@@ -51,6 +51,8 @@ export class IncomingMessage extends Readable implements http.IncomingMessage {
   get trailersDistinct() {
     return _distinct(this.trailers);
   }
+
+  _read() {}
 }
 
 function _distinct(obj: Record<string, any>) {

--- a/src/runtime/node/http/internal/request.ts
+++ b/src/runtime/node/http/internal/request.ts
@@ -1,6 +1,6 @@
 import type http from "node:http";
 import { Socket } from "node:net";
-import { Readable } from "../../stream/internal/readable";
+import { Readable } from "node:stream";
 import { rawHeaders } from "../../../_internal/utils";
 
 // Docs: https://nodejs.org/api/http.html#http_class_http_incomingmessage

--- a/src/runtime/node/http/internal/response.ts
+++ b/src/runtime/node/http/internal/response.ts
@@ -1,7 +1,7 @@
 import type http from "node:http";
 import type { Socket } from "node:net";
 import { Callback } from "../../../_internal/types";
-import { Writable } from "../../stream";
+import { Writable } from "node:stream";
 
 // Docs: https://nodejs.org/api/http.html#http_class_http_serverresponse
 // Implementation: https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js

--- a/src/runtime/node/net/internal/socket.ts
+++ b/src/runtime/node/net/internal/socket.ts
@@ -1,6 +1,6 @@
 import type * as net from "node:net";
 import { Callback, BufferEncoding } from "../../../_internal/types";
-import { Duplex } from "../../stream/internal/duplex";
+import { Duplex } from "node:stream";
 
 // Docs: https://nodejs.org/api/net.html#net_class_net_socket
 export class Socket extends Duplex implements net.Socket {

--- a/src/runtime/node/stream/internal/readable.ts
+++ b/src/runtime/node/stream/internal/readable.ts
@@ -1,7 +1,7 @@
 import type * as stream from "node:stream";
 import type { BufferEncoding, Callback } from "../../../_internal/types";
 import { createNotImplementedError } from "../../../_internal/utils";
-import { EventEmitter } from "../../events";
+import { EventEmitter } from "node:events";
 
 // Docs: https://nodejs.org/api/stream.html#stream_readable_streams
 // Implementation: https://github.com/nodejs/node/blob/master/lib/internal/streams/readable.js

--- a/src/runtime/node/stream/internal/writable.ts
+++ b/src/runtime/node/stream/internal/writable.ts
@@ -1,7 +1,7 @@
 import type * as stream from "node:stream";
 import type { BufferEncoding, Callback } from "../../../_internal/types";
 
-import { EventEmitter } from "../../events";
+import { EventEmitter } from "node:events";
 
 // Docs: https://nodejs.org/api/stream.html#stream_writable_streams
 // Implementation: https://github.com/nodejs/node/blob/master/lib/internal/streams/writable.js

--- a/src/runtime/node/tls/internal/server.ts
+++ b/src/runtime/node/tls/internal/server.ts
@@ -1,6 +1,6 @@
 import type tls from "node:tls";
 import { createNotImplementedError } from "../../../_internal/utils";
-import { Server as _Server } from "../../net";
+import { Server as _Server } from "node:net";
 
 export class Server extends _Server implements tls.Server {
   constructor(

--- a/src/runtime/node/tls/internal/tls-socket.ts
+++ b/src/runtime/node/tls/internal/tls-socket.ts
@@ -1,5 +1,5 @@
 import type tls from "node:tls";
-import { Socket } from "../../net";
+import { Socket } from "node:net";
 import { createNotImplementedError } from "../../../_internal/utils";
 
 export class TLSSocket extends Socket implements tls.TLSSocket {

--- a/src/runtime/node/tty/internal/read-stream.ts
+++ b/src/runtime/node/tty/internal/read-stream.ts
@@ -1,5 +1,5 @@
 import type tty from "node:tty";
-import { Socket } from "../../net";
+import { Socket } from "node:net";
 
 export class ReadStream extends Socket implements tty.ReadStream {
   isRaw = false;

--- a/test/workerd/tests.mjs
+++ b/test/workerd/tests.mjs
@@ -128,3 +128,19 @@ export const workerd_path = {
     assert.strictEqual(pathPosix.delimiter, ":");
   },
 };
+
+// --- node:http
+
+export const workerd_http = {
+  async test() {
+    const http = await import("unenv/runtime/node/http");
+    const net = await import("unenv/runtime/node/net");
+    const message = new http.IncomingMessage(new net.Socket());
+    await assert.doesNotThrow(async () => {
+      // Would throw if the async iterator is not implemented
+      for await (const chunk of message) {
+        // empty
+      }
+    });
+  },
+};


### PR DESCRIPTION
We should never import Nodejs packages with relative import as unenv will not get a chance to replace those.

Relates to https://github.com/opennextjs/opennextjs-cloudflare/issues/147: It looks like the issue is caused by the unenv implementation of `Readable#[Symbol.AsyncIterator]`:

```ts
  async *[Symbol.asyncIterator](): NodeJS.AsyncIterator<any> {
    throw createNotImplementedError("Readable.asyncIterator");
  }
```

However this should never be used by workerd that has builtin `stream`.

The second commits add a dummy `IncomingMessage#_read` to make testing easier.


