### PR TITLE
refactor: use `node:events` instead of relative path 

### DIFF
--- a/src/runtime/node/http/internal/request.ts
+++ b/src/runtime/node/http/internal/request.ts
@@ -1,5 +1,6 @@
 import type http from "node:http";
 import { Socket } from "node:net";
+// Relative import required, see https://github.com/unjs/unenv/issues/353
 import { Readable } from "../../stream/internal/readable";
 import { rawHeaders } from "../../../_internal/utils";
 

--- a/src/runtime/node/http/internal/request.ts
+++ b/src/runtime/node/http/internal/request.ts
@@ -1,6 +1,6 @@
 import type http from "node:http";
 import { Socket } from "node:net";
-// Relative import required, see https://github.com/unjs/unenv/issues/353
+// Relative stream import required, see https://github.com/unjs/unenv/issues/353
 import { Readable } from "../../stream/internal/readable";
 import { rawHeaders } from "../../../_internal/utils";
 

--- a/src/runtime/node/http/internal/response.ts
+++ b/src/runtime/node/http/internal/response.ts
@@ -1,6 +1,7 @@
 import type http from "node:http";
 import type { Socket } from "node:net";
 import { Callback } from "../../../_internal/types";
+// Relative stream import required, see https://github.com/unjs/unenv/issues/353
 import { Writable } from "../../stream";
 
 // Docs: https://nodejs.org/api/http.html#http_class_http_serverresponse

--- a/src/runtime/node/net/internal/socket.ts
+++ b/src/runtime/node/net/internal/socket.ts
@@ -1,5 +1,6 @@
 import type * as net from "node:net";
 import { Callback, BufferEncoding } from "../../../_internal/types";
+// Relative stream import required, see https://github.com/unjs/unenv/issues/353
 import { Duplex } from "../../stream/internal/duplex";
 
 // Docs: https://nodejs.org/api/net.html#net_class_net_socket

--- a/src/runtime/node/stream/internal/readable.ts
+++ b/src/runtime/node/stream/internal/readable.ts
@@ -1,7 +1,7 @@
 import type * as stream from "node:stream";
 import type { BufferEncoding, Callback } from "../../../_internal/types";
 import { createNotImplementedError } from "../../../_internal/utils";
-import { EventEmitter } from "../../events";
+import { EventEmitter } from "node:events";
 
 // Docs: https://nodejs.org/api/stream.html#stream_readable_streams
 // Implementation: https://github.com/nodejs/node/blob/master/lib/internal/streams/readable.js

--- a/src/runtime/node/stream/internal/writable.ts
+++ b/src/runtime/node/stream/internal/writable.ts
@@ -1,7 +1,7 @@
 import type * as stream from "node:stream";
 import type { BufferEncoding, Callback } from "../../../_internal/types";
 
-import { EventEmitter } from "../../events";
+import { EventEmitter } from "node:events";
 
 // Docs: https://nodejs.org/api/stream.html#stream_writable_streams
 // Implementation: https://github.com/nodejs/node/blob/master/lib/internal/streams/writable.js

--- a/src/runtime/node/tls/internal/server.ts
+++ b/src/runtime/node/tls/internal/server.ts
@@ -1,5 +1,6 @@
 import type tls from "node:tls";
 import { createNotImplementedError } from "../../../_internal/utils";
+// Relative net import required, see https://github.com/unjs/unenv/issues/353
 import { Server as _Server } from "../../net";
 
 export class Server extends _Server implements tls.Server {

--- a/src/runtime/node/tls/internal/tls-socket.ts
+++ b/src/runtime/node/tls/internal/tls-socket.ts
@@ -1,5 +1,5 @@
 import type tls from "node:tls";
-import { Socket } from "../../net";
+import { Socket } from "node:net";
 import { createNotImplementedError } from "../../../_internal/utils";
 
 export class TLSSocket extends Socket implements tls.TLSSocket {

--- a/src/runtime/node/tls/internal/tls-socket.ts
+++ b/src/runtime/node/tls/internal/tls-socket.ts
@@ -1,4 +1,5 @@
 import type tls from "node:tls";
+// Relative net import required, see https://github.com/unjs/unenv/issues/353
 import { Socket } from "../../net";
 import { createNotImplementedError } from "../../../_internal/utils";
 

--- a/src/runtime/node/tls/internal/tls-socket.ts
+++ b/src/runtime/node/tls/internal/tls-socket.ts
@@ -1,5 +1,5 @@
 import type tls from "node:tls";
-import { Socket } from "node:net";
+import { Socket } from "../../net";
 import { createNotImplementedError } from "../../../_internal/utils";
 
 export class TLSSocket extends Socket implements tls.TLSSocket {

--- a/src/runtime/node/tty/internal/read-stream.ts
+++ b/src/runtime/node/tty/internal/read-stream.ts
@@ -1,4 +1,5 @@
 import type tty from "node:tty";
+// Relative net import required, see https://github.com/unjs/unenv/issues/353
 import { Socket } from "../../net";
 
 export class ReadStream extends Socket implements tty.ReadStream {


### PR DESCRIPTION
Change node:events import from relative to package import.

@pi0 There are a few relative imports for the net package. I left them untouched to stay on the safe side.
Let me know if it's the right thing to do - if it is, I'd like to add comment there too.
Thanks 🙏

Context: https://github.com/unjs/unenv/issues/353#issuecomment-2508064030