### PR TITLE
fix(cloudflare): import notImplemented using a relative path

### DIFF
--- a/src/runtime/node/module/$cloudflare.ts
+++ b/src/runtime/node/module/$cloudflare.ts
@@ -54,7 +54,7 @@ import {
   syncBuiltinESMExports,
   wrap,
 } from "./index";
-import { notImplemented } from "src/runtime/_internal/utils";
+import { notImplemented } from "../../_internal/utils";
 
 const workerdModule = process.getBuiltinModule("node:module");
 


### PR DESCRIPTION
This was trigering the following error:

```
-> % npx wrangler dev

 ⛅️ wrangler 3.91.0
-------------------


✘ [ERROR] Build failed with 1 error:

  ✘ [ERROR] Could not resolve "src/runtime/_internal/utils"
  
  
  node_modules/.pnpm/unenv@file+..+unenv/node_modules/unenv/runtime/node/module/$cloudflare.mjs:53:31:
        53 │ import { notImplemented } from "src/runtime/_internal/utils";
           ╵                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  
    You can mark the path "src/runtime/_internal/utils" as external to exclude it from the bundle,
  which will remove this error.
  
```

edits: 
- the cumprit is this [PR](https://github.com/unjs/unenv/pull/351) last week by me
- I create https://github.com/unjs/unenv/issues/357 to try to solve this at build time