### PR TITLE
chore: disallow `src/` imports with eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,6 +26,17 @@ export default unjs(
       "@typescript-eslint/no-unused-expressions": 0,
       "unicorn/prefer-global-this": 0,
       "unicorn/prefer-math-min-max": 0,
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["src/*"],
+              message: "Use relative imports instead.",
+            },
+          ],
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
fixes #357

```
-> % pnpm lint

> unenv@1.9.0 lint /Users/vberchet/code/work/unenv
> eslint . && prettier -c src test

/Users/vberchet/code/work/unenv/src/runtime/node/fs/index.ts
  16:1  error  'src/runtime/_internal/utils' import is restricted from being used by a pattern. Use relative imports instead  no-restricted-imports

✖ 1 problem (1 error, 0 warnings)

 ELIFECYCLE  Command failed with exit code 1.
 ```