### PR TITLE
test: add workerd test for unenv/fetch

### DIFF
--- a/test/workerd/tests.mjs
+++ b/test/workerd/tests.mjs
@@ -128,3 +128,26 @@ export const workerd_path = {
     assert.strictEqual(pathPosix.delimiter, ":");
   },
 };
+
+// --- unenv:fetch
+
+export const unenv_fetch = {
+  async test() {
+    // https://srvx.unjs.io/guide/node#reverse-compatibility
+    // This method is used in h3 v1 and Nitro v2 for server fetch without network roundtrip + internal caching system.
+    const { createFetch, createCall } = await import("unenv/runtime/fetch");
+    const serverFetch = createFetch(
+      createCall(async (req, res) => {
+        res.end(
+          JSON.stringify({ "req.url": req.url, "req.headers": req.headers }),
+        );
+      }),
+    );
+    const res = await serverFetch("/test", { headers: { foo: "bar" } });
+    const resBody = await res.json();
+    assert.deepEqual(resBody, {
+      "req.url": "/test",
+      "req.headers": { foo: "bar", host: "localhost" },
+    });
+  },
+};


### PR DESCRIPTION
Ref: Added as part of #353 discussions. /cc @vicb

This PR adds a test for h3 fetch util used today in Nitro v1 and h3 for various purposes.


