### PR TITLE
refactor(node:process): set `process.domain` to `undefined`

### DIFF
--- a/src/runtime/node/process/internal/process.ts
+++ b/src/runtime/node/process/internal/process.ts
@@ -243,7 +243,8 @@ export const _stopProfilerIdleNotifier = notImplemented(
 export const _tickCallback = notImplemented("process._tickCallback");
 export const _linkedBinding = notImplemented("process._linkedBinding");
 
-export const domain = mock.__createMock__("process.domain");
+// Mocking domain cuases troubles, see unjs/unenv#367
+export const domain = undefined;
 export const initgroups = notImplemented("process.initgroups");
 export const moduleLoadList = [] as string[];
 export const reallyExit = noop;

--- a/src/runtime/node/process/internal/process.ts
+++ b/src/runtime/node/process/internal/process.ts
@@ -243,7 +243,7 @@ export const _stopProfilerIdleNotifier = notImplemented(
 export const _tickCallback = notImplemented("process._tickCallback");
 export const _linkedBinding = notImplemented("process._linkedBinding");
 
-// Mocking domain cuases troubles, see unjs/unenv#367
+// Mocking domain causes troubles, see unjs/unenv#367
 export const domain = undefined;
 export const initgroups = notImplemented("process.initgroups");
 export const moduleLoadList = [] as string[];


### PR DESCRIPTION
`process.domain` was implemented as `mock.__createMock__("process.domain");`

Which means that 

1. `process.domain.bind(fn)` returned function will not call `fn`
2. `process.domain.run(fn, ...args)` will not execute `fn`

After the cloudflare hybrid polyfill [made use of `process.domain`](https://github.com/unjs/unenv/pull/335) we started [seeing issue](https://github.com/cloudflare/workers-sdk/issues/7072) with the `pg` npm packages.

Those issues are triggered by [code similar to](https://github.com/search?q=repo%3Abrianc%2Fnode-postgres%20%22.domain%22&type=code): 

```ts
if (process.domain && config.callback) {
  this.callback = process.domain.bind(config.callback)
}
```

In this snippet, the callback (`config.callback`) will never be executed.

We considered implementing bind as `(fn) => fn` but because `node:domain` has been deprecated since NodeJs 4, the current PR seems to be a reasonable fix.

If the current PR causes troubles, we can consider implementing `bind` and `run`