### PR TITLE
fix(nodelss): use valid esm inject paths

### DIFF
--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -83,8 +83,8 @@ const nodeless: Preset & { alias: Map<string, string> } = {
 
   inject: {
     global: "unenv/runtime/node/_global",
-    process: "unenv/runtime/node/process",
-    Buffer: ["buffer", "Buffer"],
+    process: "unenv/runtime/node/process/index",
+    Buffer: ["unenv/runtime/node/buffer/index", "Buffer"],
     performance: "unenv/runtime/polyfill/performance",
   },
 

--- a/test/workerd/tests.mjs
+++ b/test/workerd/tests.mjs
@@ -8,7 +8,7 @@ globalThis.process = process;
 
 export const crypto_getRandomValues = {
   async test() {
-    const crypto = await import("unenv/runtime/node/crypto");
+    const crypto = await import("unenv/runtime/node/crypto/index");
 
     const array = new Uint32Array(10);
     crypto.getRandomValues(array);
@@ -21,7 +21,7 @@ export const crypto_getRandomValues = {
 
 export const url_parse = {
   async test() {
-    const url = await import("unenv/runtime/node/url");
+    const url = await import("unenv/runtime/node/url/index");
 
     assert.throws(
       () => {
@@ -36,7 +36,7 @@ export const url_parse = {
 
 export const unenv_polyfills_buffer = {
   async test() {
-    const buffer = await import("unenv/runtime/node/buffer");
+    const buffer = await import("unenv/runtime/node/buffer/index");
     const Buffer = buffer.Buffer;
     assert.strictEqual(typeof buffer.isAscii, "function");
     assert.strictEqual(typeof buffer.isUtf8, "function");
@@ -97,7 +97,7 @@ export const workerd_modules = {
 
 export const util_implements = {
   async test() {
-    const { types } = await import("unenv/runtime/node/util");
+    const { types } = await import("unenv/runtime/node/util/index");
     assert.strictEqual(types.isExternal("hello world"), false);
     assert.strictEqual(types.isAnyArrayBuffer(new ArrayBuffer(0)), true);
   },
@@ -107,13 +107,13 @@ export const util_implements = {
 
 export const unenv_polyfills_path = {
   async test() {
-    const pathWin32 = await import("unenv/runtime/node/path/win32");
+    const pathWin32 = await import("unenv/runtime/node/path/win32/index");
     assert.strictEqual(typeof pathWin32.resolve, "function");
     // Note: unenv uses `unjs/pathe` which behavior differs from Node.js
     // See https://github.com/unjs/pathe
     assert.strictEqual(pathWin32.sep, "/");
     assert.strictEqual(pathWin32.delimiter, ":");
-    const pathPosix = await import("unenv/runtime/node/path/posix");
+    const pathPosix = await import("unenv/runtime/node/path/posix/index");
     assert.strictEqual(typeof pathPosix.resolve, "function");
   },
 };

--- a/test/workerd/tests.mjs
+++ b/test/workerd/tests.mjs
@@ -8,7 +8,7 @@ globalThis.process = process;
 
 export const crypto_getRandomValues = {
   async test() {
-    const crypto = await import("unenv/runtime/node/crypto/index");
+    const crypto = await import("unenv/runtime/node/crypto");
 
     const array = new Uint32Array(10);
     crypto.getRandomValues(array);
@@ -21,7 +21,7 @@ export const crypto_getRandomValues = {
 
 export const url_parse = {
   async test() {
-    const url = await import("unenv/runtime/node/url/index");
+    const url = await import("unenv/runtime/node/url");
 
     assert.throws(
       () => {
@@ -36,7 +36,7 @@ export const url_parse = {
 
 export const unenv_polyfills_buffer = {
   async test() {
-    const buffer = await import("unenv/runtime/node/buffer/index");
+    const buffer = await import("unenv/runtime/node/buffer");
     const Buffer = buffer.Buffer;
     assert.strictEqual(typeof buffer.isAscii, "function");
     assert.strictEqual(typeof buffer.isUtf8, "function");
@@ -97,7 +97,7 @@ export const workerd_modules = {
 
 export const util_implements = {
   async test() {
-    const { types } = await import("unenv/runtime/node/util/index");
+    const { types } = await import("unenv/runtime/node/util");
     assert.strictEqual(types.isExternal("hello world"), false);
     assert.strictEqual(types.isAnyArrayBuffer(new ArrayBuffer(0)), true);
   },
@@ -107,13 +107,13 @@ export const util_implements = {
 
 export const unenv_polyfills_path = {
   async test() {
-    const pathWin32 = await import("unenv/runtime/node/path/win32/index");
+    const pathWin32 = await import("unenv/runtime/node/path/win32");
     assert.strictEqual(typeof pathWin32.resolve, "function");
     // Note: unenv uses `unjs/pathe` which behavior differs from Node.js
     // See https://github.com/unjs/pathe
     assert.strictEqual(pathWin32.sep, "/");
     assert.strictEqual(pathWin32.delimiter, ":");
-    const pathPosix = await import("unenv/runtime/node/path/posix/index");
+    const pathPosix = await import("unenv/runtime/node/path/posix");
     assert.strictEqual(typeof pathPosix.resolve, "function");
   },
 };


### PR DESCRIPTION
[As per `exports` definition in package.json](https://github.com/unjs/unenv/blob/main/package.json#L16-L19), some modules don’t have fully qualified specifier so using them throws `ERR_MODULE_NOT_FOUND` error.

Two other things to note:

1. Is there a reason why we don’t use unev version of Buffer? Currently it’s expected `buffer` package is installed but I thinks was not intended?

2. I’ve tried running tests for Workerd but I’m getting following error:

<details>
<summary>Error output</summary>

```
Workerd: 1.20241202.0 (compatibility date: 2024-12-02)
Module fallback server listening on http://localhost:8888
Running tests...
workerd/server/server.c++:4025: debug: [ TEST ] tests:crypto_getRandomValues
workerd/server/server.c++:3052: error: Fallback service failed to fetch module; payload = 404 page not found
; spec = /?specifier=%2Funenv%2Fruntime%2Fnode%2Fcrypto%2Findex&referrer=%2Ftests&rawSpecifier=unenv%2Fruntime%2Fnode%2Fcrypto%2Findex
workerd/io/worker.c++:2067: info: uncaught exception; source = Uncaught (in promise); stack = Error: No such module "unenv/runtime/node/crypto/index".
    at Object.test (tests:11:20)
workerd/io/worker.c++:2067: info: uncaught exception; source = Uncaught (async); stack = Error: No such module "unenv/runtime/node/crypto/index".
    at Object.test (tests:11:20)
workerd/server/server.c++:4033: debug: [ FAIL ] tests:crypto_getRandomValues
workerd/server/server.c++:4025: debug: [ TEST ] tests:unenv_polyfills_buffer
workerd/server/server.c++:3052: error: Fallback service failed to fetch module; payload = 404 page not found
; spec = /?specifier=%2Funenv%2Fruntime%2Fnode%2Fbuffer%2Findex&referrer=%2Ftests&rawSpecifier=unenv%2Fruntime%2Fnode%2Fbuffer%2Findex
workerd/io/worker.c++:2067: info: uncaught exception; source = Uncaught (in promise); stack = Error: No such module "unenv/runtime/node/buffer/index".
    at Object.test (tests:39:20)
workerd/io/worker.c++:2067: info: uncaught exception; source = Uncaught (async); stack = Error: No such module "unenv/runtime/node/buffer/index".
    at Object.test (tests:39:20)
workerd/server/server.c++:4033: debug: [ FAIL ] tests:unenv_polyfills_buffer
workerd/server/server.c++:4025: debug: [ TEST ] tests:unenv_polyfills_path
workerd/server/server.c++:3052: error: Fallback service failed to fetch module; payload = 404 page not found
; spec = /?specifier=%2Funenv%2Fruntime%2Fnode%2Fpath%2Fwin32%2Findex&referrer=%2Ftests&rawSpecifier=unenv%2Fruntime%2Fnode%2Fpath%2Fwin32%2Findex
workerd/io/worker.c++:2067: info: uncaught exception; source = Uncaught (in promise); stack = Error: No such module "unenv/runtime/node/path/win32/index".
    at Object.test (tests:110:23)
workerd/io/worker.c++:2067: info: uncaught exception; source = Uncaught (async); stack = Error: No such module "unenv/runtime/node/path/win32/index".
    at Object.test (tests:110:23)
workerd/server/server.c++:4033: debug: [ FAIL ] tests:unenv_polyfills_path
workerd/server/server.c++:4025: debug: [ TEST ] tests:url_parse
workerd/server/server.c++:3052: error: Fallback service failed to fetch module; payload = 404 page not found
; spec = /?specifier=%2Funenv%2Fruntime%2Fnode%2Furl%2Findex&referrer=%2Ftests&rawSpecifier=unenv%2Fruntime%2Fnode%2Furl%2Findex
workerd/io/worker.c++:2067: info: uncaught exception; source = Uncaught (in promise); stack = Error: No such module "unenv/runtime/node/url/index".
    at Object.test (tests:24:17)
workerd/io/worker.c++:2067: info: uncaught exception; source = Uncaught (async); stack = Error: No such module "unenv/runtime/node/url/index".
    at Object.test (tests:24:17)
workerd/server/server.c++:4033: debug: [ FAIL ] tests:url_parse
workerd/server/server.c++:4025: debug: [ TEST ] tests:util_implements
workerd/server/server.c++:3052: error: Fallback service failed to fetch module; payload = 404 page not found
; spec = /?specifier=%2Funenv%2Fruntime%2Fnode%2Futil%2Findex&referrer=%2Ftests&rawSpecifier=unenv%2Fruntime%2Fnode%2Futil%2Findex
workerd/io/worker.c++:2067: info: uncaught exception; source = Uncaught (in promise); stack = Error: No such module "unenv/runtime/node/util/index".
    at Object.test (tests:100:23)
workerd/io/worker.c++:2067: info: uncaught exception; source = Uncaught (async); stack = Error: No such module "unenv/runtime/node/util/index".
    at Object.test (tests:100:23)
workerd/server/server.c++:4033: debug: [ FAIL ] tests:util_implements
workerd/server/server.c++:4025: debug: [ TEST ] tests:workerd_implements_buffer
workerd/server/server.c++:4033: debug: [ PASS ] tests:workerd_implements_buffer
workerd/server/server.c++:4025: debug: [ TEST ] tests:workerd_modules
workerd/server/server.c++:4033: debug: [ PASS ] tests:workerd_modules
workerd/server/server.c++:4025: debug: [ TEST ] tests:workerd_path
workerd/server/server.c++:4033: debug: [ PASS ] tests:workerd_path
Tests failed!
```

</details>
