### PR TITLE
feat: presets meta

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -15,6 +15,7 @@ import nodeCompatPreset from "./presets/nodeless";
  */
 export function defineEnv(opts: CreateEnvOptions = {}): {
   env: Environment;
+  presets: Preset[];
 } {
   const presets: Preset[] = [];
 
@@ -32,7 +33,7 @@ export function defineEnv(opts: CreateEnvOptions = {}): {
 
   const resolvedEnv = env(...presets);
 
-  return { env: resolvedEnv };
+  return { env: resolvedEnv, presets };
 }
 
 /**

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -1,4 +1,5 @@
 import type { Preset } from "../types";
+import { version } from "../../package.json";
 
 // Built-in APIs provided by workerd.
 // https://developers.cloudflare.com/workers/runtime-apis/nodejs/
@@ -42,6 +43,10 @@ const hybridNodeCompatModules = [
 ];
 
 const cloudflarePreset: Preset = {
+  meta: {
+    name: "unenv:cloudflare",
+    version,
+  },
   alias: {
     ...Object.fromEntries(
       cloudflareNodeCompatModules.flatMap((p) => [

--- a/src/presets/node.ts
+++ b/src/presets/node.ts
@@ -1,7 +1,13 @@
 import { NodeBuiltinModules } from "../utils";
 import type { Preset } from "../types";
+import { version } from "../../package.json";
 
 export default {
+  meta: {
+    name: "unenv:node",
+    version,
+  },
+
   alias: {
     "node-fetch": "unenv/runtime/npm/node-fetch",
     "cross-fetch": "unenv/runtime/npm/cross-fetch",

--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -1,7 +1,13 @@
 import { NodeBuiltinModules, mapArrToVal } from "../utils";
 import type { Preset } from "../types";
+import { version } from "../../package.json";
 
 const nodeless: Preset & { alias: Map<string, string> } = {
+  meta: {
+    name: "unenv:nodeless",
+    version,
+  },
+
   alias: {
     // Generic mock for built-ins
     ...mapArrToVal("unenv/runtime/mock/proxy-cjs", NodeBuiltinModules),

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,17 +27,17 @@ export interface Preset {
     /**
      * Preset name.
      */
-    name?: string;
+    readonly name?: string;
 
     /**
      * Preset version.
      */
-    version?: string;
+    readonly version?: string;
 
     /**
      * Path to preset directory usable for absolute path imports
      */
-    path?: string;
+    readonly path?: string;
   };
 
   alias?: Environment["alias"];

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,23 @@ export interface Environment {
 }
 
 export interface Preset {
+  meta?: {
+    /**
+     * Preset name.
+     */
+    name?: string;
+
+    /**
+     * Preset version.
+     */
+    version?: string;
+
+    /**
+     * Path to preset directory usable for absolute path imports
+     */
+    path?: string;
+  };
+
   alias?: Environment["alias"];
   // inject's value is nullable to support overrides/subtraction
   inject?: { [key: string]: string | string[] | false };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "strict": true,
     "declaration": true,
+    "resolveJsonModule": true,
     "types": [
       "node"
     ],


### PR DESCRIPTION
This PR adds `meta` to the presets which is useful for external presets meta. 

Presets are exposed from `defineEnv` for inspection and `path` is useful for #373