### PR TITLE
fix(defineEnv): fallback support for `unenv-nightly`

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -44,7 +44,22 @@ export function defineEnv(opts: CreateEnvOptions = {}): {
     const resolveOpts: ResolveOptions = {
       url: resolvePaths,
     };
-    const _resolve = (id: string) => resolvePathSync(id, resolveOpts);
+
+    const _resolve = (id: string) => {
+      try {
+        return resolvePathSync(id, resolveOpts);
+      } catch {
+        if (id.startsWith("unenv/")) {
+          try {
+            return resolvePathSync(
+              id.replace("unenv/", "unenv-nightly/"),
+              resolveOpts,
+            );
+          } catch {}
+        }
+      }
+      return id;
+    };
 
     // Resolve aliases
     for (const alias in resolvedEnv.alias) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -45,20 +45,18 @@ export function defineEnv(opts: CreateEnvOptions = {}): {
       url: resolvePaths,
     };
 
-    const _resolve = (id: string) => {
+    const _tryResolve = (id: string) => {
       try {
         return resolvePathSync(id, resolveOpts);
-      } catch {
-        if (id.startsWith("unenv/")) {
-          try {
-            return resolvePathSync(
-              id.replace("unenv/", "unenv-nightly/"),
-              resolveOpts,
-            );
-          } catch {}
-        }
+      } catch {}
+    };
+
+    const _resolve = (id: string) => {
+      let resolved = _tryResolve(id);
+      if (!resolved && id.startsWith("unenv/")) {
+        resolved = _tryResolve(id.replace("unenv/", "unenv-nightly/"));
       }
-      return id;
+      return resolved || id;
     };
 
     // Resolve aliases


### PR DESCRIPTION
This PR is a hotfix for `defineEnv` utility when it is running in an aliased `unenv-nightly` package and when package manager (pnpm) does **not** rename `"name"` field in `package.json`, it causes ESM resolution to fail.

Workaroud is to fallback to `unenv/` => `unenv-nightly/` and then id as-is.