### PR TITLE
feat(timers): implement `active` and `_unrefActive` exports

### DIFF
--- a/src/runtime/node/timers/$cloudflare.ts
+++ b/src/runtime/node/timers/$cloudflare.ts
@@ -39,7 +39,8 @@ import {
   clearImmediateFallback as clearImmediate,
 } from "./internal/set-immediate";
 
-export default <typeof nodeTimers>{
+export default {
+  // @ts-expect-error deprecated
   _unrefActive,
   active,
   clearImmediate,
@@ -51,4 +52,4 @@ export default <typeof nodeTimers>{
   setInterval,
   setTimeout,
   unenroll,
-};
+} satisfies typeof nodeTimers;

--- a/src/runtime/node/timers/index.ts
+++ b/src/runtime/node/timers/index.ts
@@ -23,7 +23,7 @@ export const setImmediate: typeof timers.setImmediate =
 export const setTimeout: typeof timers.setTimeout =
   globalThis.setTimeout?.bind(globalThis) || setTimeoutFallback;
 export const setInterval: typeof timers.setInterval =
-  globalThis.setInterval.bind(globalThis) || setIntervalFallback;
+  globalThis.setInterval?.bind(globalThis) || setIntervalFallback;
 
 export const active = notImplemented("timers.active");
 export const _unrefActive = notImplemented("timers._unrefActive");

--- a/src/runtime/node/timers/index.ts
+++ b/src/runtime/node/timers/index.ts
@@ -12,18 +12,18 @@ import { setIntervalFallback } from "./internal/set-interval";
 export * as promises from "./promises";
 
 export const clearImmediate: typeof timers.clearImmediate =
-  globalThis.clearImmediate || clearImmediateFallback;
+  globalThis.clearImmediate.bind(globalThis) || clearImmediateFallback;
 export const clearInterval: typeof timers.clearInterval =
-  globalThis.clearInterval || noop;
+  globalThis.clearInterval.bind(globalThis) || noop;
 export const clearTimeout: typeof timers.clearTimeout =
-  globalThis.clearTimeout || noop;
+  globalThis.clearTimeout.bind(globalThis) || noop;
 
 export const setImmediate: typeof timers.setImmediate =
-  globalThis.setImmediate || setImmediateFallback;
+  globalThis.setImmediate.bind(globalThis) || setImmediateFallback;
 export const setTimeout: typeof timers.setTimeout =
-  globalThis.setTimeout || setTimeoutFallback;
+  globalThis.setTimeout.bind(globalThis) || setTimeoutFallback;
 export const setInterval: typeof timers.setInterval =
-  globalThis.setInterval || setIntervalFallback;
+  globalThis.setInterval.bind(globalThis) || setIntervalFallback;
 
 export const active = notImplemented("timers.active");
 export const _unrefActive = notImplemented("timers._unrefActive");

--- a/src/runtime/node/timers/index.ts
+++ b/src/runtime/node/timers/index.ts
@@ -1,6 +1,6 @@
 import { notImplemented } from "../../_internal/utils";
 import noop from "../../mock/noop";
-import type timers from "node:timers";
+import type nodeTimers from "node:timers";
 import promises from "./promises";
 import { setTimeoutFallback } from "./internal/set-timeout";
 import {
@@ -11,26 +11,29 @@ import { setIntervalFallback } from "./internal/set-interval";
 
 export * as promises from "./promises";
 
-export const clearImmediate: typeof timers.clearImmediate =
+export const clearImmediate: typeof nodeTimers.clearImmediate =
   globalThis.clearImmediate?.bind(globalThis) || clearImmediateFallback;
-export const clearInterval: typeof timers.clearInterval =
+export const clearInterval: typeof nodeTimers.clearInterval =
   globalThis.clearInterval?.bind(globalThis) || noop;
-export const clearTimeout: typeof timers.clearTimeout =
+export const clearTimeout: typeof nodeTimers.clearTimeout =
   globalThis.clearTimeout?.bind(globalThis) || noop;
 
-export const setImmediate: typeof timers.setImmediate =
+export const setImmediate: typeof nodeTimers.setImmediate =
   globalThis.setImmediate?.bind(globalThis) || setImmediateFallback;
-export const setTimeout: typeof timers.setTimeout =
+export const setTimeout: typeof nodeTimers.setTimeout =
   globalThis.setTimeout?.bind(globalThis) || setTimeoutFallback;
-export const setInterval: typeof timers.setInterval =
+export const setInterval: typeof nodeTimers.setInterval =
   globalThis.setInterval?.bind(globalThis) || setIntervalFallback;
 
-export const active = notImplemented("timers.active");
-export const _unrefActive = notImplemented("timers._unrefActive");
+export const active = function active(timeout: NodeJS.Timeout | undefined) {
+  timeout?.refresh?.();
+};
+export const _unrefActive = active;
 export const enroll = notImplemented("timers.enroll");
 export const unenroll = notImplemented("timers.unenroll");
 
-export default <typeof timers>{
+export default {
+  // @ts-expect-error: deprecated
   _unrefActive,
   active,
   clearImmediate,
@@ -42,4 +45,4 @@ export default <typeof timers>{
   setInterval,
   setTimeout,
   unenroll,
-};
+} satisfies typeof nodeTimers;

--- a/src/runtime/node/timers/index.ts
+++ b/src/runtime/node/timers/index.ts
@@ -19,7 +19,7 @@ export const clearTimeout: typeof timers.clearTimeout =
   globalThis.clearTimeout?.bind(globalThis) || noop;
 
 export const setImmediate: typeof timers.setImmediate =
-  globalThis.setImmediate.bind(globalThis) || setImmediateFallback;
+  globalThis.setImmediate?.bind(globalThis) || setImmediateFallback;
 export const setTimeout: typeof timers.setTimeout =
   globalThis.setTimeout.bind(globalThis) || setTimeoutFallback;
 export const setInterval: typeof timers.setInterval =

--- a/src/runtime/node/timers/index.ts
+++ b/src/runtime/node/timers/index.ts
@@ -14,7 +14,7 @@ export * as promises from "./promises";
 export const clearImmediate: typeof timers.clearImmediate =
   globalThis.clearImmediate.bind(globalThis) || clearImmediateFallback;
 export const clearInterval: typeof timers.clearInterval =
-  globalThis.clearInterval.bind(globalThis) || noop;
+  globalThis.clearInterval?.bind(globalThis) || noop;
 export const clearTimeout: typeof timers.clearTimeout =
   globalThis.clearTimeout.bind(globalThis) || noop;
 

--- a/src/runtime/node/timers/index.ts
+++ b/src/runtime/node/timers/index.ts
@@ -16,7 +16,7 @@ export const clearImmediate: typeof timers.clearImmediate =
 export const clearInterval: typeof timers.clearInterval =
   globalThis.clearInterval?.bind(globalThis) || noop;
 export const clearTimeout: typeof timers.clearTimeout =
-  globalThis.clearTimeout.bind(globalThis) || noop;
+  globalThis.clearTimeout?.bind(globalThis) || noop;
 
 export const setImmediate: typeof timers.setImmediate =
   globalThis.setImmediate.bind(globalThis) || setImmediateFallback;

--- a/src/runtime/node/timers/index.ts
+++ b/src/runtime/node/timers/index.ts
@@ -12,7 +12,7 @@ import { setIntervalFallback } from "./internal/set-interval";
 export * as promises from "./promises";
 
 export const clearImmediate: typeof timers.clearImmediate =
-  globalThis.clearImmediate.bind(globalThis) || clearImmediateFallback;
+  globalThis.clearImmediate?.bind(globalThis) || clearImmediateFallback;
 export const clearInterval: typeof timers.clearInterval =
   globalThis.clearInterval?.bind(globalThis) || noop;
 export const clearTimeout: typeof timers.clearTimeout =

--- a/src/runtime/node/timers/index.ts
+++ b/src/runtime/node/timers/index.ts
@@ -21,7 +21,7 @@ export const clearTimeout: typeof timers.clearTimeout =
 export const setImmediate: typeof timers.setImmediate =
   globalThis.setImmediate?.bind(globalThis) || setImmediateFallback;
 export const setTimeout: typeof timers.setTimeout =
-  globalThis.setTimeout.bind(globalThis) || setTimeoutFallback;
+  globalThis.setTimeout?.bind(globalThis) || setTimeoutFallback;
 export const setInterval: typeof timers.setInterval =
   globalThis.setInterval.bind(globalThis) || setIntervalFallback;
 

--- a/test/workerd/tests.mjs
+++ b/test/workerd/tests.mjs
@@ -166,6 +166,11 @@ export const workerd_timers = {
     timers.clearTimeout(timers.setTimeout(() => null, 1000));
     timers.clearInterval(timers.setInterval(() => null, 1000));
     timers.clearImmediate(timers.setImmediate(() => null));
+
+    timers.active(timers.setTimeout(() => null, 10));
+    timers.active(undefined);
+    timers._unrefActive(timers.setTimeout(() => null, 10));
+    timers._unrefActive(undefined);
   },
 };
 

--- a/test/workerd/tests.mjs
+++ b/test/workerd/tests.mjs
@@ -157,6 +157,18 @@ export const workerd_dns = {
   },
 };
 
+// --- node:timers
+
+export const workerd_timers = {
+  async test() {
+    const timers = await import("unenv/runtime/node/timers");
+
+    timers.clearTimeout(timers.setTimeout(() => null, 1000));
+    timers.clearInterval(timers.setInterval(() => null, 1000));
+    timers.clearImmediate(timers.setImmediate(() => null));
+  },
+};
+
 // --- unenv:fetch
 
 // https://github.com/unjs/unenv/issues/364


### PR DESCRIPTION
While `active` is deprecated, it used by popular libs.

[mysql](https://github.com/mysqljs/mysql/blob/dc9c152a87ec51a1f647447268917243d2eab1fd/lib/protocol/Timer.js#L14)

```js
Timer.prototype.active = function active() {
  if (this._timeout) {
    if (this._timeout.refresh) {
      this._timeout.refresh();
    } else {
      Timers.active(this._timeout);
    }
  }
};
```

ref: [NodeJS implementation](https://github.com/nodejs/node/blob/0e7ec5e7a1427eb418bf82833a5c308cb8e0ecda/lib/timers.js#L354)

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #385 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #384 
<!-- GitButler Footer Boundary Bottom -->

