### PR TITLE
refactor(tty): ReadStream depend on node:net

### DIFF
--- a/src/runtime/node/tty/internal/read-stream.ts
+++ b/src/runtime/node/tty/internal/read-stream.ts
@@ -1,6 +1,5 @@
 import type tty from "node:tty";
-// Relative net import required, see https://github.com/unjs/unenv/issues/353
-import { Socket } from "../../net";
+import { Socket } from "node:net";
 
 export class ReadStream extends Socket implements tty.ReadStream {
   fd: number;


### PR DESCRIPTION
The `WriteStream` already depends on `node:net`, I think this should be ok here?