### PR TITLE
chore: remove old deno process polyfill

### DIFF
--- a/src/runtime/polyfill/deno-env.ts
+++ b/src/runtime/polyfill/deno-env.ts
@@ -1,2 +1,0 @@
-// @ts-expect-error Deno global
-Object.assign(process.env, Deno.env.toObject());


### PR DESCRIPTION
Since Deno 2 the `process` variable is available globally.

Fixes https://github.com/unjs/unenv/issues/394