### PR TITLE
feat(cloudflare): add `node:net` and `node:timers`

### DIFF
--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -4,7 +4,7 @@ import { version } from "../../package.json";
 // Built-in APIs provided by workerd.
 // https://developers.cloudflare.com/workers/runtime-apis/nodejs/
 // https://github.com/cloudflare/workerd/tree/main/src/node
-// Last checked: 2024-10-22
+// Last checked: 2025-01-24
 const cloudflareNodeCompatModules = [
   "_stream_duplex",
   "_stream_passthrough",
@@ -18,6 +18,8 @@ const cloudflareNodeCompatModules = [
   "dns",
   "dns/promises",
   "events",
+  "net",
+  "net/promises",
   "path",
   "path/posix",
   "path/win32",
@@ -27,6 +29,8 @@ const cloudflareNodeCompatModules = [
   "stream/promises",
   "stream/web",
   "string_decoder",
+  "timers",
+  "timers/promises",
   "url",
   "util/types",
   "zlib",
@@ -40,7 +44,6 @@ const hybridNodeCompatModules = [
   "crypto",
   "module",
   "process",
-  "timers",
   "util",
 ];
 

--- a/test/workerd/tests.mjs
+++ b/test/workerd/tests.mjs
@@ -161,7 +161,7 @@ export const workerd_dns = {
 
 export const workerd_timers = {
   async test() {
-    const timers = await import("unenv/runtime/node/timers");
+    const timers = await import("node:timers");
 
     timers.clearTimeout(timers.setTimeout(() => null, 1000));
     timers.clearInterval(timers.setInterval(() => null, 1000));
@@ -169,8 +169,18 @@ export const workerd_timers = {
 
     timers.active(timers.setTimeout(() => null, 10));
     timers.active(undefined);
-    timers._unrefActive(timers.setTimeout(() => null, 10));
-    timers._unrefActive(undefined);
+
+    timers.setImmediate(() => null);
+  },
+};
+
+// --- node:net
+
+export const workerd_net = {
+  async test() {
+    const net = await import("node:net");
+    assert.strictEqual(typeof net.createConnection, "function");
+    assert.throws(() => net.createServer(), /not implemented/);
   },
 };
 


### PR DESCRIPTION
Adds node:net and node:timers since they're both fully implemented in workers right now.