### PR TITLE
fix: add ./runtime/node/string_decoder/index/ to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "license": "MIT",
   "sideEffects": false,
   "exports": {
+    "./runtime/node/string_decoder/index/": {
+      "types": "./runtime/node/string_decoder/index.d.ts",
+      "require": "./runtime/node/string_decoder/index.cjs",
+      "import": "./runtime/node/string_decoder/index.mjs"
+    },
     ".": {
       "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",


### PR DESCRIPTION
fix most exports problem in nuxt , cloudflare and netlify 
https://github.com/nitrojs/nitro/issues/2631
![image](https://github.com/user-attachments/assets/9cf53c83-e19d-4d78-b5f7-d01dc07221e2)



<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
