### PR TITLE
fix: add `string_decoder` / `node:string_decoder` to nodeless aliases

### DIFF
--- a/src/presets/nodeless.ts
+++ b/src/presets/nodeless.ts
@@ -65,6 +65,7 @@ const nodeless: Preset & { alias: Map<string, string> } = {
         "wasi",
         "worker_threads",
         "zlib",
+        "string_decoder",
       ].map((m) => [m, `unenv/runtime/node/${m}/index`]),
     ),
 


### PR DESCRIPTION
I think string_decorder is a standard nodejs libraray, so I just add `string_decorder` to list. 
I'm not quite sure about the logic of the code in this part. If there's any issue with my code, you can make the necessary modifications. Thank you very much.