### PR TITLE
refactor!: remove legacy presets in favor of `defineEnv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,16 @@ deno install --dev unenv
 Using `env` utility and built-in presets, `unenv` will provide an abstract configuration that can be used in bundlers ([rollup.js](https://rollupjs.org), [webpack](https://webpack.js.org), etc.).
 
 ```js
-import { env } from "unenv";
+import { defineEnv } from "unenv";
 
-const { alias, inject, polyfill, external } = env({}, {}, {});
+const { env } = defineEnv({
+  nodeCompat: true,
+  resolve: true,
+  presets: [],
+  overrides: {},
+});
+
+const { alias, inject, polyfill, external } = env;
 ```
 
 **Note:** You can provide as many presets as you want. unenv will merge them internally and the right-most preset has a higher priority.

--- a/src/env.ts
+++ b/src/env.ts
@@ -9,6 +9,7 @@ import nodeCompatPreset from "./presets/nodeless";
  * ```ts
  * const { env } = defineEnv({
  *  nodeCompat: true,
+ *  resolve: true,
  *  presets: [myPreset],
  *  overrides: {}
  * });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export * from "./utils";
-export * from "./presets";
 export * from "./env";

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,2 +1,0 @@
-export { default as node } from "./node";
-export { default as nodeless } from "./nodeless";


### PR DESCRIPTION
This PR drops legacy merging until `env` in favor of the new `defineEnv` util (#372)

Also drops internals `mapArrToVal` and `NodeBuiltinModules`