### PR TITLE
refactor: mark notImplemented constructors as side-effect free

### DIFF
--- a/src/runtime/_internal/utils.ts
+++ b/src/runtime/_internal/utils.ts
@@ -1,5 +1,6 @@
 import type { HeadersObject } from "./types";
 
+/*@__NO_SIDE_EFFECTS__*/
 export function rawHeaders(headers: HeadersObject) {
   const rawHeaders = [];
   for (const key in headers) {
@@ -15,6 +16,8 @@ export function rawHeaders(headers: HeadersObject) {
 }
 
 type Fn = (...args: any[]) => any;
+
+/*@__NO_SIDE_EFFECTS__*/
 export function mergeFns(...functions: Fn[]) {
   return function (...args: any[]) {
     for (const fn of functions) {
@@ -23,10 +26,12 @@ export function mergeFns(...functions: Fn[]) {
   };
 }
 
+/*@__NO_SIDE_EFFECTS__*/
 export function createNotImplementedError(name: string) {
   return new Error(`[unenv] ${name} is not implemented yet!`);
 }
 
+/*@__NO_SIDE_EFFECTS__*/
 export function notImplemented<Fn extends (...args: any) => any>(
   name: string,
 ): Fn {
@@ -42,13 +47,16 @@ export interface Promisifiable {
   __promisify__: () => Promise<any>;
 }
 
-export function notImplementedAsync(name: string): Promisifiable {
-  const fn = notImplemented(name) as any;
-  fn.__promisify__ = () => notImplemented(name + ".__promisify__");
+/*@__NO_SIDE_EFFECTS__*/
+export function /*@__PURE__*/ notImplementedAsync(name: string): Promisifiable {
+  const fn = /*@__PURE__*/ notImplemented(name) as any;
+  fn.__promisify__ = () =>
+    /*@__PURE__*/ notImplemented(name + ".__promisify__");
   fn.native = fn;
   return fn;
 }
 
+/*@__NO_SIDE_EFFECTS__*/
 export function notImplementedClass<T = unknown>(name: string): T {
   return class {
     readonly __unenv__ = true;

--- a/src/runtime/_internal/utils.ts
+++ b/src/runtime/_internal/utils.ts
@@ -48,10 +48,9 @@ export interface Promisifiable {
 }
 
 /*@__NO_SIDE_EFFECTS__*/
-export function /*@__PURE__*/ notImplementedAsync(name: string): Promisifiable {
-  const fn = /*@__PURE__*/ notImplemented(name) as any;
-  fn.__promisify__ = () =>
-    /*@__PURE__*/ notImplemented(name + ".__promisify__");
+export function notImplementedAsync(name: string): Promisifiable {
+  const fn = notImplemented(name) as any;
+  fn.__promisify__ = () => notImplemented(name + ".__promisify__");
   fn.native = fn;
   return fn;
 }

--- a/src/runtime/node/assert.ts
+++ b/src/runtime/node/assert.ts
@@ -928,7 +928,7 @@ function expectsNoError(
 const assert = Object.assign(ok, {}) as typeof nodeAssert;
 
 // deprecated
-export const CallTracker = notImplementedClass(
+export const CallTracker = /*@__PURE__*/ notImplementedClass(
   "asset.CallTracker",
 ) as typeof nodeAssert.CallTracker;
 

--- a/src/runtime/node/buffer.ts
+++ b/src/runtime/node/buffer.ts
@@ -21,10 +21,12 @@ export { File } from "./internal/buffer/file";
 
 // @ts-expect-eerror https://github.com/unjs/unenv/issues/64
 export const Blob = globalThis.Blob as unknown as typeof buffer.Blob;
-export const resolveObjectURL = notImplemented("buffer.resolveObjectURL");
-export const transcode = notImplemented("buffer.transcode");
-export const isUtf8 = notImplemented("buffer.isUtf8");
-export const isAscii = notImplemented("buffer.isAscii");
+export const resolveObjectURL = /*@__PURE__*/ notImplemented(
+  "buffer.resolveObjectURL",
+);
+export const transcode = /*@__PURE__*/ notImplemented("buffer.transcode");
+export const isUtf8 = /*@__PURE__*/ notImplemented("buffer.isUtf8");
+export const isAscii = /*@__PURE__*/ notImplemented("buffer.isAscii");
 
 export const btoa = globalThis.btoa.bind(globalThis);
 export const atob = globalThis.atob.bind(globalThis);

--- a/src/runtime/node/child_process.ts
+++ b/src/runtime/node/child_process.ts
@@ -2,29 +2,27 @@ import { notImplemented, notImplementedClass } from "../_internal/utils";
 import type child_process from "node:child_process";
 
 export const ChildProcess: typeof child_process.ChildProcess =
-  notImplementedClass("child_process.ChildProcess");
+  /*@__PURE__*/ notImplementedClass("child_process.ChildProcess");
 
-export const _forkChild = notImplemented("child_process.ChildProcess");
+export const _forkChild = /*@__PURE__*/ notImplemented(
+  "child_process.ChildProcess",
+);
 
 export const exec: typeof child_process.exec =
-  notImplemented("child_process.exec");
-export const execFile: typeof child_process.execFile = notImplemented(
-  "child_process.execFile",
-);
-export const execFileSync: typeof child_process.execFileSync = notImplemented(
-  "child_process.execFileSync",
-);
-export const execSync: typeof child_process.execSync = notImplemented(
-  "child_process.execSyn",
-);
+  /*@__PURE__*/ notImplemented("child_process.exec");
+export const execFile: typeof child_process.execFile =
+  /*@__PURE__*/ notImplemented("child_process.execFile");
+export const execFileSync: typeof child_process.execFileSync =
+  /*@__PURE__*/ notImplemented("child_process.execFileSync");
+export const execSync: typeof child_process.execSync =
+  /*@__PURE__*/ notImplemented("child_process.execSyn");
 export const fork: typeof child_process.fork =
-  notImplemented("child_process.fork");
-export const spawn: typeof child_process.spawn = notImplemented(
+  /*@__PURE__*/ notImplemented("child_process.fork");
+export const spawn: typeof child_process.spawn = /*@__PURE__*/ notImplemented(
   "child_process.spawn",
 );
-export const spawnSync: typeof child_process.spawnSync = notImplemented(
-  "child_process.spawnSync",
-);
+export const spawnSync: typeof child_process.spawnSync =
+  /*@__PURE__*/ notImplemented("child_process.spawnSync");
 
 export default <typeof child_process>{
   ChildProcess,

--- a/src/runtime/node/cluster.ts
+++ b/src/runtime/node/cluster.ts
@@ -19,18 +19,17 @@ export const schedulingPolicy: typeof nodeCluster.schedulingPolicy = SCHED_RR;
 export const settings: typeof nodeCluster.settings = {};
 export const workers: typeof nodeCluster.workers = {};
 
-export const fork: typeof nodeCluster.fork = notImplemented("cluster.fork");
+export const fork: typeof nodeCluster.fork =
+  /*@__PURE__*/ notImplemented("cluster.fork");
 
 export const disconnect: typeof nodeCluster.disconnect =
-  notImplemented("cluster.disconnect");
+  /*@__PURE__*/ notImplemented("cluster.disconnect");
 
-export const setupPrimary: typeof nodeCluster.setupPrimary = notImplemented(
-  "cluster.setupPrimary",
-);
+export const setupPrimary: typeof nodeCluster.setupPrimary =
+  /*@__PURE__*/ notImplemented("cluster.setupPrimary");
 
-export const setupMaster: typeof nodeCluster.setupMaster = notImplemented(
-  "cluster.setupMaster",
-);
+export const setupMaster: typeof nodeCluster.setupMaster =
+  /*@__PURE__*/ notImplemented("cluster.setupMaster");
 
 // Make ESM coverage happy
 export const _events = [];

--- a/src/runtime/node/console.ts
+++ b/src/runtime/node/console.ts
@@ -25,7 +25,7 @@ export const createTask =
   /*@__PURE__*/ notImplemented("console.createTask");
 
 export const assert: typeof console.assert =
-  notImplemented<typeof console.assert>("console.assert");
+  /*@__PURE__*/ notImplemented<typeof console.assert>("console.assert");
 
 // noop
 export const clear: typeof console.clear = _console?.clear ?? noop;

--- a/src/runtime/node/console.ts
+++ b/src/runtime/node/console.ts
@@ -21,7 +21,8 @@ export const warn: typeof console.warn = _console?.warn ?? error;
 
 // https://developer.chrome.com/docs/devtools/console/api#createtask
 export const createTask =
-  (_console as any)?.createTask ?? notImplemented("console.createTask");
+  (_console as any)?.createTask ??
+  /*@__PURE__*/ notImplemented("console.createTask");
 
 export const assert: typeof console.assert =
   notImplemented<typeof console.assert>("console.assert");

--- a/src/runtime/node/dns.ts
+++ b/src/runtime/node/dns.ts
@@ -13,36 +13,39 @@ export const Resolver: typeof dns.Resolver =
 export const getDefaultResultOrder: typeof dns.getDefaultResultOrder = () =>
   "verbatim";
 export const getServers: typeof dns.getServers = () => [];
-export const lookup: typeof dns.lookup = notImplementedAsync("dns.lookup");
+export const lookup: typeof dns.lookup =
+  /*@__PURE__*/ notImplementedAsync("dns.lookup");
 export const lookupService: typeof dns.lookupService =
-  notImplementedAsync("dns.lookupService");
-export const resolve: typeof dns.resolve = notImplementedAsync("dns.resolve");
+  /*@__PURE__*/ notImplementedAsync("dns.lookupService");
+export const resolve: typeof dns.resolve =
+  /*@__PURE__*/ notImplementedAsync("dns.resolve");
 export const resolve4: typeof dns.resolve4 =
-  notImplementedAsync("dns.resolve4");
+  /*@__PURE__*/ notImplementedAsync("dns.resolve4");
 export const resolve6: typeof dns.resolve6 =
-  notImplementedAsync("dns.resolve6");
+  /*@__PURE__*/ notImplementedAsync("dns.resolve6");
 export const resolveAny: typeof dns.resolveAny =
-  notImplementedAsync("dns.resolveAny");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveAny");
 export const resolveCaa: typeof dns.resolveCaa =
-  notImplementedAsync("dns.resolveCaa");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveCaa");
 export const resolveCname: typeof dns.resolveCname =
-  notImplementedAsync("dns.resolveCname");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveCname");
 export const resolveMx: typeof dns.resolveMx =
-  notImplementedAsync("dns.resolveMx");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveMx");
 export const resolveNaptr: typeof dns.resolveNaptr =
-  notImplementedAsync("dns.resolveNaptr");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveNaptr");
 export const resolveNs: typeof dns.resolveNs =
-  notImplementedAsync("dns.resolveNs");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveNs");
 export const resolvePtr: typeof dns.resolvePtr =
-  notImplementedAsync("dns.resolvePtr");
+  /*@__PURE__*/ notImplementedAsync("dns.resolvePtr");
 export const resolveSoa: typeof dns.resolveSoa =
-  notImplementedAsync("dns.resolveSoa");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveSoa");
 export const resolveSrv: typeof dns.resolveSrv =
-  notImplementedAsync("dns.resolveSrv");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveSrv");
 export const resolveTxt: typeof dns.resolveTxt =
-  notImplementedAsync("dns.resolveTxt");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveTxt");
 
-export const reverse: typeof dns.reverse = notImplemented("dns.reverse");
+export const reverse: typeof dns.reverse =
+  /*@__PURE__*/ notImplemented("dns.reverse");
 export const setDefaultResultOrder: typeof dns.setDefaultResultOrder = noop;
 export const setServers: typeof dns.setServers = noop;
 

--- a/src/runtime/node/dns/promises.ts
+++ b/src/runtime/node/dns/promises.ts
@@ -10,36 +10,39 @@ export const Resolver: typeof dns.Resolver =
 export const getDefaultResultOrder: typeof dns.getDefaultResultOrder = () =>
   "verbatim";
 export const getServers: typeof dns.getServers = () => [];
-export const lookup: typeof dns.lookup = notImplementedAsync("dns.lookup");
+export const lookup: typeof dns.lookup =
+  /*@__PURE__*/ notImplementedAsync("dns.lookup");
 export const lookupService: typeof dns.lookupService =
-  notImplementedAsync("dns.lookupService");
-export const resolve: typeof dns.resolve = notImplementedAsync("dns.resolve");
+  /*@__PURE__*/ notImplementedAsync("dns.lookupService");
+export const resolve: typeof dns.resolve =
+  /*@__PURE__*/ notImplementedAsync("dns.resolve");
 export const resolve4: typeof dns.resolve4 =
-  notImplementedAsync("dns.resolve4");
+  /*@__PURE__*/ notImplementedAsync("dns.resolve4");
 export const resolve6: typeof dns.resolve6 =
-  notImplementedAsync("dns.resolve6");
+  /*@__PURE__*/ notImplementedAsync("dns.resolve6");
 export const resolveAny: typeof dns.resolveAny =
-  notImplementedAsync("dns.resolveAny");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveAny");
 export const resolveCaa: typeof dns.resolveCaa =
-  notImplementedAsync("dns.resolveCaa");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveCaa");
 export const resolveCname: typeof dns.resolveCname =
-  notImplementedAsync("dns.resolveCname");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveCname");
 export const resolveMx: typeof dns.resolveMx =
-  notImplementedAsync("dns.resolveMx");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveMx");
 export const resolveNaptr: typeof dns.resolveNaptr =
-  notImplementedAsync("dns.resolveNaptr");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveNaptr");
 export const resolveNs: typeof dns.resolveNs =
-  notImplementedAsync("dns.resolveNs");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveNs");
 export const resolvePtr: typeof dns.resolvePtr =
-  notImplementedAsync("dns.resolvePtr");
+  /*@__PURE__*/ notImplementedAsync("dns.resolvePtr");
 export const resolveSoa: typeof dns.resolveSoa =
-  notImplementedAsync("dns.resolveSoa");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveSoa");
 export const resolveSrv: typeof dns.resolveSrv =
-  notImplementedAsync("dns.resolveSrv");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveSrv");
 export const resolveTxt: typeof dns.resolveTxt =
-  notImplementedAsync("dns.resolveTxt");
+  /*@__PURE__*/ notImplementedAsync("dns.resolveTxt");
 
-export const reverse: typeof dns.reverse = notImplemented("dns.reverse");
+export const reverse: typeof dns.reverse =
+  /*@__PURE__*/ notImplemented("dns.reverse");
 export const setDefaultResultOrder: typeof dns.setDefaultResultOrder = noop;
 export const setServers: typeof dns.setServers = noop;
 

--- a/src/runtime/node/http.ts
+++ b/src/runtime/node/http.ts
@@ -40,7 +40,9 @@ export const setMaxIdleHTTPParsers = notImplemented<
   typeof http.setMaxIdleHTTPParsers
 >("http.setMaxIdleHTTPParsers");
 
-export const _connectionListener = notImplemented("http._connectionListener");
+export const _connectionListener = /*@__PURE__*/ notImplemented(
+  "http._connectionListener",
+);
 
 export const WebSocket =
   globalThis.WebSocket || notImplementedClass<WebSocket>("WebSocket");

--- a/src/runtime/node/http.ts
+++ b/src/runtime/node/http.ts
@@ -11,9 +11,10 @@ export * from "./internal/http/request";
 export * from "./internal/http/response";
 
 export const createServer =
-  notImplemented<typeof http.createServer>("http.createServer");
-export const request = notImplemented<typeof http.request>("http.request");
-export const get = notImplemented<typeof http.get>("http.get");
+  /*@__PURE__*/ notImplemented<typeof http.createServer>("http.createServer");
+export const request =
+  /*@__PURE__*/ notImplemented<typeof http.request>("http.request");
+export const get = /*@__PURE__*/ notImplemented<typeof http.get>("http.get");
 
 export const Server: typeof http.Server = mock.__createMock__("http.Server");
 
@@ -28,15 +29,15 @@ export const Agent: typeof http.Agent = mock.__createMock__("http.Agent");
 
 export const globalAgent: typeof http.globalAgent = new Agent();
 
-export const validateHeaderName = notImplemented<
+export const validateHeaderName = /*@__PURE__*/ notImplemented<
   typeof http.validateHeaderName
 >("http.validateHeaderName");
 
-export const validateHeaderValue = notImplemented<
+export const validateHeaderValue = /*@__PURE__*/ notImplemented<
   typeof http.validateHeaderValue
 >("http.validateHeaderValue");
 
-export const setMaxIdleHTTPParsers = notImplemented<
+export const setMaxIdleHTTPParsers = /*@__PURE__*/ notImplemented<
   typeof http.setMaxIdleHTTPParsers
 >("http.setMaxIdleHTTPParsers");
 
@@ -45,13 +46,16 @@ export const _connectionListener = /*@__PURE__*/ notImplemented(
 );
 
 export const WebSocket =
-  globalThis.WebSocket || notImplementedClass<WebSocket>("WebSocket");
+  globalThis.WebSocket ||
+  /*@__PURE__*/ notImplementedClass<WebSocket>("WebSocket");
 
 export const CloseEvent =
-  globalThis.CloseEvent || notImplementedClass<CloseEvent>("CloseEvent");
+  globalThis.CloseEvent ||
+  /*@__PURE__*/ notImplementedClass<CloseEvent>("CloseEvent");
 
 export const MessageEvent =
-  globalThis.MessageEvent || notImplementedClass<MessageEvent>("MessageEvent");
+  globalThis.MessageEvent ||
+  /*@__PURE__*/ notImplementedClass<MessageEvent>("MessageEvent");
 
 export default <typeof http>{
   ...consts,

--- a/src/runtime/node/http2.ts
+++ b/src/runtime/node/http2.ts
@@ -10,9 +10,10 @@ export const createSecureServer = notImplemented<
 >("http2.createSecureServer");
 export const createServer =
   notImplemented<typeof http2.createServer>("http2.createServer");
-export const connect: typeof http2.connect = notImplemented("http2.connect");
+export const connect: typeof http2.connect =
+  /*@__PURE__*/ notImplemented("http2.connect");
 export const performServerHandshake: typeof http2.performServerHandshake =
-  notImplemented("http2.performServerHandshake ");
+  /*@__PURE__*/ notImplemented("http2.performServerHandshake ");
 
 export const Http2ServerRequest: typeof http2.Http2ServerRequest =
   mock.__createMock__("http2.Http2ServerRequest");

--- a/src/runtime/node/http2.ts
+++ b/src/runtime/node/http2.ts
@@ -5,11 +5,11 @@ import { constants } from "./internal/http2/constants";
 
 export { constants } from "./internal/http2/constants";
 
-export const createSecureServer = notImplemented<
+export const createSecureServer = /*@__PURE__*/ notImplemented<
   typeof http2.createSecureServer
 >("http2.createSecureServer");
 export const createServer =
-  notImplemented<typeof http2.createServer>("http2.createServer");
+  /*@__PURE__*/ notImplemented<typeof http2.createServer>("http2.createServer");
 export const connect: typeof http2.connect =
   /*@__PURE__*/ notImplemented("http2.connect");
 export const performServerHandshake: typeof http2.performServerHandshake =

--- a/src/runtime/node/https.ts
+++ b/src/runtime/node/https.ts
@@ -4,7 +4,7 @@ import { notImplemented, notImplementedClass } from "../_internal/utils";
 import mock from "../mock/proxy";
 
 export const Server: typeof nodeHttps.Server =
-  notImplementedClass("https.Server");
+  /*@__PURE__*/ notImplementedClass("https.Server");
 
 export const Agent: typeof nodeHttps.Agent = mock.__createMock__("https.Agent");
 export const globalAgent: typeof nodeHttps.globalAgent = new Agent();

--- a/src/runtime/node/https.ts
+++ b/src/runtime/node/https.ts
@@ -9,13 +9,16 @@ export const Server: typeof nodeHttps.Server =
 export const Agent: typeof nodeHttps.Agent = mock.__createMock__("https.Agent");
 export const globalAgent: typeof nodeHttps.globalAgent = new Agent();
 
-export const get = notImplemented<typeof nodeHttps.get>("https.get");
+export const get =
+  /*@__PURE__*/ notImplemented<typeof nodeHttps.get>("https.get");
 
 export const createServer =
-  notImplemented<typeof nodeHttps.createServer>("https.createServer");
+  /*@__PURE__*/ notImplemented<typeof nodeHttps.createServer>(
+    "https.createServer",
+  );
 
 export const request =
-  notImplemented<typeof nodeHttps.request>("https.request");
+  /*@__PURE__*/ notImplemented<typeof nodeHttps.request>("https.request");
 
 export default <typeof nodeHttps>{
   Server,

--- a/src/runtime/node/internal/crypto/node.ts
+++ b/src/runtime/node/internal/crypto/node.ts
@@ -72,10 +72,12 @@ export const checkPrimeSync = notImplemented<typeof nodeCrypto.checkPrimeSync>(
 );
 
 /** @deprecated */
-export const createCipher = notImplemented("crypto.createCipher");
+export const createCipher = /*@__PURE__*/ notImplemented("crypto.createCipher");
 
 /** @deprecated */
-export const createDecipher = notImplemented("crypto.createDecipher");
+export const createDecipher = /*@__PURE__*/ notImplemented(
+  "crypto.createDecipher",
+);
 
 export const pseudoRandomBytes = notImplemented<
   typeof nodeCrypto.pseudoRandomBytes
@@ -235,60 +237,60 @@ export const hash = notImplemented<(typeof nodeCrypto)["hash"]>("crypto.hash");
 
 // ---- Unimplemented Classes ----
 
-export const Certificate = notImplementedClass(
+export const Certificate = /*@__PURE__*/ notImplementedClass(
   "crypto.Certificate",
 ) as unknown as typeof nodeCrypto.Certificate;
 
-export const Cipher = notImplementedClass(
+export const Cipher = /*@__PURE__*/ notImplementedClass(
   "crypto.Cipher",
 ) as unknown as typeof nodeCrypto.Cipher;
 
-export const Cipheriv = notImplementedClass(
+export const Cipheriv = /*@__PURE__*/ notImplementedClass(
   "crypto.Cipheriv",
   // @ts-expect-error not typed yet
 ) as unknown as typeof nodeCrypto.Cipheriv;
 
-export const Decipher = notImplementedClass(
+export const Decipher = /*@__PURE__*/ notImplementedClass(
   "crypto.Decipher",
 ) as unknown as typeof nodeCrypto.Decipher;
 
-export const Decipheriv = notImplementedClass(
+export const Decipheriv = /*@__PURE__*/ notImplementedClass(
   "crypto.Decipheriv",
   // @ts-expect-error not typed yet
 ) as unknown as typeof nodeCrypto.Decipheriv;
 
-export const DiffieHellman = notImplementedClass(
+export const DiffieHellman = /*@__PURE__*/ notImplementedClass(
   "crypto.DiffieHellman",
 ) as unknown as typeof nodeCrypto.DiffieHellman;
 
-export const DiffieHellmanGroup = notImplementedClass(
+export const DiffieHellmanGroup = /*@__PURE__*/ notImplementedClass(
   "crypto.DiffieHellmanGroup",
 ) as unknown as typeof nodeCrypto.DiffieHellmanGroup;
 
-export const ECDH = notImplementedClass(
+export const ECDH = /*@__PURE__*/ notImplementedClass(
   "crypto.ECDH",
 ) as unknown as typeof nodeCrypto.ECDH;
 
-export const Hash = notImplementedClass(
+export const Hash = /*@__PURE__*/ notImplementedClass(
   "crypto.Hash",
 ) as unknown as typeof nodeCrypto.Hash;
 
-export const Hmac = notImplementedClass(
+export const Hmac = /*@__PURE__*/ notImplementedClass(
   "crypto.Hmac",
 ) as unknown as typeof nodeCrypto.Hmac;
 
-export const KeyObject = notImplementedClass(
+export const KeyObject = /*@__PURE__*/ notImplementedClass(
   "crypto.KeyObject",
 ) as unknown as typeof nodeCrypto.KeyObject;
 
-export const Sign = notImplementedClass(
+export const Sign = /*@__PURE__*/ notImplementedClass(
   "crypto.Sign",
 ) as unknown as typeof nodeCrypto.Sign;
 
-export const Verify = notImplementedClass(
+export const Verify = /*@__PURE__*/ notImplementedClass(
   "crypto.Verify",
 ) as unknown as typeof nodeCrypto.Verify;
 
-export const X509Certificate = notImplementedClass(
+export const X509Certificate = /*@__PURE__*/ notImplementedClass(
   "crypto.X509Certificate",
 ) as unknown as typeof nodeCrypto.X509Certificate;

--- a/src/runtime/node/internal/crypto/node.ts
+++ b/src/runtime/node/internal/crypto/node.ts
@@ -65,11 +65,13 @@ export const constants = {} as typeof nodeCrypto.constants;
 // ---- Unimplemented utils ----
 
 export const checkPrime =
-  notImplemented<typeof nodeCrypto.checkPrime>("crypto.checkPrime");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.checkPrime>(
+    "crypto.checkPrime",
+  );
 
-export const checkPrimeSync = notImplemented<typeof nodeCrypto.checkPrimeSync>(
-  "crypto.checkPrimeSync",
-);
+export const checkPrimeSync = /*@__PURE__*/ notImplemented<
+  typeof nodeCrypto.checkPrimeSync
+>("crypto.checkPrimeSync");
 
 /** @deprecated */
 export const createCipher = /*@__PURE__*/ notImplemented("crypto.createCipher");
@@ -79,161 +81,185 @@ export const createDecipher = /*@__PURE__*/ notImplemented(
   "crypto.createDecipher",
 );
 
-export const pseudoRandomBytes = notImplemented<
+export const pseudoRandomBytes = /*@__PURE__*/ notImplemented<
   typeof nodeCrypto.pseudoRandomBytes
 >("crypto.pseudoRandomBytes");
 
-export const createCipheriv = notImplemented<typeof nodeCrypto.createCipheriv>(
-  "crypto.createCipheriv",
-);
+export const createCipheriv = /*@__PURE__*/ notImplemented<
+  typeof nodeCrypto.createCipheriv
+>("crypto.createCipheriv");
 
-export const createDecipheriv = notImplemented<
+export const createDecipheriv = /*@__PURE__*/ notImplemented<
   typeof nodeCrypto.createDecipheriv
 >("crypto.createDecipheriv");
 
-export const createDiffieHellman = notImplemented<
+export const createDiffieHellman = /*@__PURE__*/ notImplemented<
   typeof nodeCrypto.createDiffieHellman
 >("crypto.createDiffieHellman");
 
-export const createDiffieHellmanGroup = notImplemented<
+export const createDiffieHellmanGroup = /*@__PURE__*/ notImplemented<
   typeof nodeCrypto.createDiffieHellmanGroup
 >("crypto.createDiffieHellmanGroup");
 
 export const createECDH =
-  notImplemented<typeof nodeCrypto.createECDH>("crypto.createECDH");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.createECDH>(
+    "crypto.createECDH",
+  );
 
 export const createHash =
-  notImplemented<typeof nodeCrypto.createHash>("crypto.createHash");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.createHash>(
+    "crypto.createHash",
+  );
 
 export const createHmac =
-  notImplemented<typeof nodeCrypto.createHmac>("crypto.createHmac");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.createHmac>(
+    "crypto.createHmac",
+  );
 
-export const createPrivateKey = notImplemented<
+export const createPrivateKey = /*@__PURE__*/ notImplemented<
   typeof nodeCrypto.createPrivateKey
 >("crypto.createPrivateKey");
 
-export const createPublicKey = notImplemented<
+export const createPublicKey = /*@__PURE__*/ notImplemented<
   typeof nodeCrypto.createPublicKey
 >("crypto.createPublicKey");
 
-export const createSecretKey = notImplemented<
+export const createSecretKey = /*@__PURE__*/ notImplemented<
   typeof nodeCrypto.createSecretKey
 >("crypto.createSecretKey");
 
 export const createSign =
-  notImplemented<typeof nodeCrypto.createSign>("crypto.createSign");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.createSign>(
+    "crypto.createSign",
+  );
 
-export const createVerify = notImplemented<typeof nodeCrypto.createVerify>(
-  "crypto.createVerify",
-);
+export const createVerify = /*@__PURE__*/ notImplemented<
+  typeof nodeCrypto.createVerify
+>("crypto.createVerify");
 
-export const diffieHellman = notImplemented<typeof nodeCrypto.diffieHellman>(
-  "crypto.diffieHellman",
-);
+export const diffieHellman = /*@__PURE__*/ notImplemented<
+  typeof nodeCrypto.diffieHellman
+>("crypto.diffieHellman");
 
-export const generatePrime = notImplemented<typeof nodeCrypto.generatePrime>(
-  "crypto.generatePrime",
-);
+export const generatePrime = /*@__PURE__*/ notImplemented<
+  typeof nodeCrypto.generatePrime
+>("crypto.generatePrime");
 
-export const generatePrimeSync = notImplemented<
+export const generatePrimeSync = /*@__PURE__*/ notImplemented<
   typeof nodeCrypto.generatePrimeSync
 >("crypto.generatePrimeSync");
 
 export const getCiphers =
-  notImplemented<typeof nodeCrypto.getCiphers>("crypto.getCiphers");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.getCiphers>(
+    "crypto.getCiphers",
+  );
 
-export const getCipherInfo = notImplemented<typeof nodeCrypto.getCipherInfo>(
-  "crypto.getCipherInfo",
-);
+export const getCipherInfo = /*@__PURE__*/ notImplemented<
+  typeof nodeCrypto.getCipherInfo
+>("crypto.getCipherInfo");
 
 export const getCurves =
-  notImplemented<typeof nodeCrypto.getCurves>("crypto.getCurves");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.getCurves>("crypto.getCurves");
 
-export const getDiffieHellman = notImplemented<
+export const getDiffieHellman = /*@__PURE__*/ notImplemented<
   typeof nodeCrypto.getDiffieHellman
 >("crypto.getDiffieHellman");
 
 export const getHashes =
-  notImplemented<typeof nodeCrypto.getHashes>("crypto.getHashes");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.getHashes>("crypto.getHashes");
 
-export const hkdf = notImplemented<typeof nodeCrypto.hkdf>("crypto.hkdf");
+export const hkdf =
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.hkdf>("crypto.hkdf");
 
 export const hkdfSync =
-  notImplemented<typeof nodeCrypto.hkdfSync>("crypto.hkdfSync");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.hkdfSync>("crypto.hkdfSync");
 
-export const pbkdf2 = notImplemented<typeof nodeCrypto.pbkdf2>("crypto.pbkdf2");
+export const pbkdf2 =
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.pbkdf2>("crypto.pbkdf2");
 
 export const pbkdf2Sync =
-  notImplemented<typeof nodeCrypto.pbkdf2Sync>("crypto.pbkdf2Sync");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.pbkdf2Sync>(
+    "crypto.pbkdf2Sync",
+  );
 
-export const generateKeyPair = notImplemented<
+export const generateKeyPair = /*@__PURE__*/ notImplemented<
   typeof nodeCrypto.generateKeyPair
 >("crypto.generateKeyPair");
 
-export const generateKeyPairSync = notImplemented<
+export const generateKeyPairSync = /*@__PURE__*/ notImplemented<
   typeof nodeCrypto.generateKeyPairSync
 >("crypto.generateKeyPairSync");
 
 export const generateKey =
-  notImplemented<typeof nodeCrypto.generateKey>("crypto.generateKey");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.generateKey>(
+    "crypto.generateKey",
+  );
 
-export const generateKeySync = notImplemented<
+export const generateKeySync = /*@__PURE__*/ notImplemented<
   typeof nodeCrypto.generateKeySync
 >("crypto.generateKeySync");
 
-export const privateDecrypt = notImplemented<typeof nodeCrypto.privateDecrypt>(
-  "crypto.privateDecrypt",
-);
+export const privateDecrypt = /*@__PURE__*/ notImplemented<
+  typeof nodeCrypto.privateDecrypt
+>("crypto.privateDecrypt");
 
-export const privateEncrypt = notImplemented<typeof nodeCrypto.privateEncrypt>(
-  "crypto.privateEncrypt",
-);
+export const privateEncrypt = /*@__PURE__*/ notImplemented<
+  typeof nodeCrypto.privateEncrypt
+>("crypto.privateEncrypt");
 
-export const publicDecrypt = notImplemented<typeof nodeCrypto.publicDecrypt>(
-  "crypto.publicDecrypt",
-);
+export const publicDecrypt = /*@__PURE__*/ notImplemented<
+  typeof nodeCrypto.publicDecrypt
+>("crypto.publicDecrypt");
 
-export const publicEncrypt = notImplemented<typeof nodeCrypto.publicEncrypt>(
-  "crypto.publicEncrypt",
-);
+export const publicEncrypt = /*@__PURE__*/ notImplemented<
+  typeof nodeCrypto.publicEncrypt
+>("crypto.publicEncrypt");
 
 export const randomFill =
-  notImplemented<typeof nodeCrypto.randomFill>("crypto.randomFill");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.randomFill>(
+    "crypto.randomFill",
+  );
 
-export const randomFillSync = notImplemented<typeof nodeCrypto.randomFillSync>(
-  "crypto.randomFillSync",
-);
+export const randomFillSync = /*@__PURE__*/ notImplemented<
+  typeof nodeCrypto.randomFillSync
+>("crypto.randomFillSync");
 
 export const randomInt =
-  notImplemented<typeof nodeCrypto.randomInt>("crypto.randomInt");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.randomInt>("crypto.randomInt");
 
-export const scrypt = notImplemented<typeof nodeCrypto.scrypt>("crypto.scrypt");
+export const scrypt =
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.scrypt>("crypto.scrypt");
 
 export const scryptSync =
-  notImplemented<typeof nodeCrypto.scryptSync>("crypto.scryptSync");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.scryptSync>(
+    "crypto.scryptSync",
+  );
 
-export const sign = notImplemented<typeof nodeCrypto.sign>("crypto.sign");
+export const sign =
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.sign>("crypto.sign");
 
 export const setEngine =
-  notImplemented<typeof nodeCrypto.setEngine>("crypto.setEngine");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.setEngine>("crypto.setEngine");
 
-export const timingSafeEqual = notImplemented<
+export const timingSafeEqual = /*@__PURE__*/ notImplemented<
   typeof nodeCrypto.timingSafeEqual
 >("crypto.timingSafeEqual");
 
 export const getFips =
-  notImplemented<typeof nodeCrypto.getFips>("crypto.getFips");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.getFips>("crypto.getFips");
 
 export const setFips =
-  notImplemented<typeof nodeCrypto.setFips>("crypto.setFips");
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.setFips>("crypto.setFips");
 
-export const verify = notImplemented<typeof nodeCrypto.verify>("crypto.verify");
+export const verify =
+  /*@__PURE__*/ notImplemented<typeof nodeCrypto.verify>("crypto.verify");
 
-export const secureHeapUsed = notImplemented<typeof nodeCrypto.secureHeapUsed>(
-  "crypto.secureHeapUsed",
-);
+export const secureHeapUsed = /*@__PURE__*/ notImplemented<
+  typeof nodeCrypto.secureHeapUsed
+>("crypto.secureHeapUsed");
 
-export const hash = notImplemented<(typeof nodeCrypto)["hash"]>("crypto.hash");
+export const hash =
+  /*@__PURE__*/ notImplemented<(typeof nodeCrypto)["hash"]>("crypto.hash");
 
 // ---- Unimplemented Classes ----
 

--- a/src/runtime/node/internal/fs/fs.ts
+++ b/src/runtime/node/internal/fs/fs.ts
@@ -97,64 +97,87 @@ export const glob: typeof fs.glob =
 
 // Sync
 export const appendFileSync =
-  notImplemented<typeof fs.appendFileSync>("fs.appendFileSync");
-export const accessSync = notImplemented<typeof fs.accessSync>("fs.accessSync");
-export const chownSync = notImplemented<typeof fs.chownSync>("fs.chownSync");
-export const chmodSync = notImplemented<typeof fs.chmodSync>("fs.chmodSync");
-export const closeSync = notImplemented<typeof fs.closeSync>("fs.closeSync");
+  /*@__PURE__*/ notImplemented<typeof fs.appendFileSync>("fs.appendFileSync");
+export const accessSync =
+  /*@__PURE__*/ notImplemented<typeof fs.accessSync>("fs.accessSync");
+export const chownSync =
+  /*@__PURE__*/ notImplemented<typeof fs.chownSync>("fs.chownSync");
+export const chmodSync =
+  /*@__PURE__*/ notImplemented<typeof fs.chmodSync>("fs.chmodSync");
+export const closeSync =
+  /*@__PURE__*/ notImplemented<typeof fs.closeSync>("fs.closeSync");
 export const copyFileSync =
-  notImplemented<typeof fs.copyFileSync>("fs.copyFileSync");
-export const cpSync = notImplemented<typeof fs.cpSync>("fs.cpSync");
+  /*@__PURE__*/ notImplemented<typeof fs.copyFileSync>("fs.copyFileSync");
+export const cpSync =
+  /*@__PURE__*/ notImplemented<typeof fs.cpSync>("fs.cpSync");
 export const existsSync: typeof fs.existsSync = () => false;
-export const fchownSync = notImplemented<typeof fs.fchownSync>("fs.fchownSync");
-export const fchmodSync = notImplemented<typeof fs.fchmodSync>("fs.fchmodSync");
+export const fchownSync =
+  /*@__PURE__*/ notImplemented<typeof fs.fchownSync>("fs.fchownSync");
+export const fchmodSync =
+  /*@__PURE__*/ notImplemented<typeof fs.fchmodSync>("fs.fchmodSync");
 export const fdatasyncSync =
-  notImplemented<typeof fs.fdatasyncSync>("fs.fdatasyncSync");
-export const fstatSync = notImplemented<typeof fs.fstatSync>(
+  /*@__PURE__*/ notImplemented<typeof fs.fdatasyncSync>("fs.fdatasyncSync");
+export const fstatSync = /*@__PURE__*/ notImplemented<typeof fs.fstatSync>(
   "fs.fstatSync",
 ) as typeof fs.fstatSync;
-export const fsyncSync = notImplemented<typeof fs.fsyncSync>("fs.fsyncSync");
+export const fsyncSync =
+  /*@__PURE__*/ notImplemented<typeof fs.fsyncSync>("fs.fsyncSync");
 export const ftruncateSync =
-  notImplemented<typeof fs.ftruncateSync>("fs.ftruncateSync");
+  /*@__PURE__*/ notImplemented<typeof fs.ftruncateSync>("fs.ftruncateSync");
 export const futimesSync =
-  notImplemented<typeof fs.futimesSync>("fs.futimesSync");
-export const lchownSync = notImplemented<typeof fs.lchownSync>("fs.lchownSync");
-export const lchmodSync = notImplemented<typeof fs.lchmodSync>("fs.lchmodSync");
-export const linkSync = notImplemented<typeof fs.linkSync>("fs.linkSync");
+  /*@__PURE__*/ notImplemented<typeof fs.futimesSync>("fs.futimesSync");
+export const lchownSync =
+  /*@__PURE__*/ notImplemented<typeof fs.lchownSync>("fs.lchownSync");
+export const lchmodSync =
+  /*@__PURE__*/ notImplemented<typeof fs.lchmodSync>("fs.lchmodSync");
+export const linkSync =
+  /*@__PURE__*/ notImplemented<typeof fs.linkSync>("fs.linkSync");
 export const lutimesSync =
-  notImplemented<typeof fs.lutimesSync>("fs.lutimesSync");
-export const mkdirSync = notImplemented<typeof fs.mkdirSync>("fs.mkdirSync");
-export const mkdtempSync = notImplemented<typeof fs.mkdtempSync>(
+  /*@__PURE__*/ notImplemented<typeof fs.lutimesSync>("fs.lutimesSync");
+export const mkdirSync =
+  /*@__PURE__*/ notImplemented<typeof fs.mkdirSync>("fs.mkdirSync");
+export const mkdtempSync = /*@__PURE__*/ notImplemented<typeof fs.mkdtempSync>(
   "fs.mkdtempSync",
 ) as typeof fs.mkdtempSync;
-export const openSync = notImplemented<typeof fs.openSync>("fs.openSync");
+export const openSync =
+  /*@__PURE__*/ notImplemented<typeof fs.openSync>("fs.openSync");
 export const opendirSync =
-  notImplemented<typeof fs.opendirSync>("fs.opendirSync");
-export const readdirSync = notImplemented<typeof fs.readdirSync>(
+  /*@__PURE__*/ notImplemented<typeof fs.opendirSync>("fs.opendirSync");
+export const readdirSync = /*@__PURE__*/ notImplemented<typeof fs.readdirSync>(
   "fs.readdirSync",
 ) as unknown as typeof fs.readdirSync;
-export const readSync = notImplemented<typeof fs.readSync>("fs.readSync");
-export const readvSync = notImplemented<typeof fs.readvSync>("fs.readvSync");
-export const readFileSync = notImplemented<typeof fs.readFileSync>(
-  "fs.readFileSync",
-) as typeof fs.readFileSync;
-export const readlinkSync = notImplemented<typeof fs.readlinkSync>(
-  "fs.readlinkSync",
-) as typeof fs.readlinkSync;
-export const renameSync = notImplemented<typeof fs.renameSync>("fs.renameSync");
-export const rmSync = notImplemented<typeof fs.rmSync>("fs.rmSync");
-export const rmdirSync = notImplemented<typeof fs.rmdirSync>("fs.rmdirSync");
+export const readSync =
+  /*@__PURE__*/ notImplemented<typeof fs.readSync>("fs.readSync");
+export const readvSync =
+  /*@__PURE__*/ notImplemented<typeof fs.readvSync>("fs.readvSync");
+export const readFileSync = /*@__PURE__*/ notImplemented<
+  typeof fs.readFileSync
+>("fs.readFileSync") as typeof fs.readFileSync;
+export const readlinkSync = /*@__PURE__*/ notImplemented<
+  typeof fs.readlinkSync
+>("fs.readlinkSync") as typeof fs.readlinkSync;
+export const renameSync =
+  /*@__PURE__*/ notImplemented<typeof fs.renameSync>("fs.renameSync");
+export const rmSync =
+  /*@__PURE__*/ notImplemented<typeof fs.rmSync>("fs.rmSync");
+export const rmdirSync =
+  /*@__PURE__*/ notImplemented<typeof fs.rmdirSync>("fs.rmdirSync");
 export const symlinkSync =
-  notImplemented<typeof fs.symlinkSync>("fs.symlinkSync");
+  /*@__PURE__*/ notImplemented<typeof fs.symlinkSync>("fs.symlinkSync");
 export const truncateSync =
-  notImplemented<typeof fs.truncateSync>("fs.truncateSync");
-export const unlinkSync = notImplemented<typeof fs.unlinkSync>("fs.unlinkSync");
-export const utimesSync = notImplemented<typeof fs.utimesSync>("fs.utimesSync");
+  /*@__PURE__*/ notImplemented<typeof fs.truncateSync>("fs.truncateSync");
+export const unlinkSync =
+  /*@__PURE__*/ notImplemented<typeof fs.unlinkSync>("fs.unlinkSync");
+export const utimesSync =
+  /*@__PURE__*/ notImplemented<typeof fs.utimesSync>("fs.utimesSync");
 export const writeFileSync =
-  notImplemented<typeof fs.writeFileSync>("fs.writeFileSync");
-export const writeSync = notImplemented<typeof fs.writeSync>("fs.writeSync");
-export const writevSync = notImplemented<typeof fs.writevSync>("fs.writevSync");
-export const statfsSync = notImplemented<typeof fs.statfsSync>(
+  /*@__PURE__*/ notImplemented<typeof fs.writeFileSync>("fs.writeFileSync");
+export const writeSync =
+  /*@__PURE__*/ notImplemented<typeof fs.writeSync>("fs.writeSync");
+export const writevSync =
+  /*@__PURE__*/ notImplemented<typeof fs.writevSync>("fs.writevSync");
+export const statfsSync = /*@__PURE__*/ notImplemented<typeof fs.statfsSync>(
   "fs.statfsSync",
 ) as typeof fs.statfsSync;
-export const globSync = notImplemented<typeof fs.globSync>("fs.globSync");
+export const globSync =
+  /*@__PURE__*/ notImplemented<typeof fs.globSync>("fs.globSync");

--- a/src/runtime/node/internal/fs/fs.ts
+++ b/src/runtime/node/internal/fs/fs.ts
@@ -45,40 +45,55 @@ export const utimes: typeof fs.utimes = callbackify(fsp.utimes);
 export const writeFile: typeof fs.writeFile = callbackify(fsp.writeFile);
 export const statfs: typeof fs.statfs = callbackify(fsp.statfs);
 
-export const close: typeof fs.close = notImplementedAsync("fs.close");
-export const createReadStream: typeof fs.createReadStream = notImplementedAsync(
-  "fs.createReadStream",
-);
+export const close: typeof fs.close =
+  /*@__PURE__*/ notImplementedAsync("fs.close");
+export const createReadStream: typeof fs.createReadStream =
+  /*@__PURE__*/ notImplementedAsync("fs.createReadStream");
 export const createWriteStream: typeof fs.createWriteStream =
-  notImplementedAsync("fs.createWriteStream");
-export const exists: typeof fs.exists = notImplementedAsync("fs.exists");
-export const fchown: typeof fs.fchown = notImplementedAsync("fs.fchown");
-export const fchmod: typeof fs.fchmod = notImplementedAsync("fs.fchmod");
+  /*@__PURE__*/ notImplementedAsync("fs.createWriteStream");
+export const exists: typeof fs.exists =
+  /*@__PURE__*/ notImplementedAsync("fs.exists");
+export const fchown: typeof fs.fchown =
+  /*@__PURE__*/ notImplementedAsync("fs.fchown");
+export const fchmod: typeof fs.fchmod =
+  /*@__PURE__*/ notImplementedAsync("fs.fchmod");
 export const fdatasync: typeof fs.fdatasync =
-  notImplementedAsync("fs.fdatasync");
-export const fstat: typeof fs.fstat = notImplementedAsync("fs.fstat");
-export const fsync: typeof fs.fsync = notImplementedAsync("fs.fsync");
+  /*@__PURE__*/ notImplementedAsync("fs.fdatasync");
+export const fstat: typeof fs.fstat =
+  /*@__PURE__*/ notImplementedAsync("fs.fstat");
+export const fsync: typeof fs.fsync =
+  /*@__PURE__*/ notImplementedAsync("fs.fsync");
 export const ftruncate: typeof fs.ftruncate =
-  notImplementedAsync("fs.ftruncate");
-export const futimes: typeof fs.futimes = notImplementedAsync("fs.futimes");
+  /*@__PURE__*/ notImplementedAsync("fs.ftruncate");
+export const futimes: typeof fs.futimes =
+  /*@__PURE__*/ notImplementedAsync("fs.futimes");
 export const lstatSync: typeof fs.lstatSync =
-  notImplementedAsync("fs.lstatSync");
-export const read: typeof fs.read = notImplementedAsync("fs.read");
-export const readv: typeof fs.readv = notImplementedAsync("fs.readv");
+  /*@__PURE__*/ notImplementedAsync("fs.lstatSync");
+export const read: typeof fs.read =
+  /*@__PURE__*/ notImplementedAsync("fs.read");
+export const readv: typeof fs.readv =
+  /*@__PURE__*/ notImplementedAsync("fs.readv");
 export const realpathSync: typeof fs.realpathSync =
-  notImplementedAsync("fs.realpathSync");
-export const statSync: typeof fs.statSync = notImplementedAsync("fs.statSync");
+  /*@__PURE__*/ notImplementedAsync("fs.realpathSync");
+export const statSync: typeof fs.statSync =
+  /*@__PURE__*/ notImplementedAsync("fs.statSync");
 export const unwatchFile: typeof fs.unwatchFile =
-  notImplementedAsync("fs.unwatchFile");
-export const watch: typeof fs.watch = notImplementedAsync("fs.watch");
+  /*@__PURE__*/ notImplementedAsync("fs.unwatchFile");
+export const watch: typeof fs.watch =
+  /*@__PURE__*/ notImplementedAsync("fs.watch");
 export const watchFile: typeof fs.watchFile =
-  notImplementedAsync("fs.watchFile");
-export const write: typeof fs.write = notImplementedAsync("fs.write");
-export const writev: typeof fs.writev = notImplementedAsync("fs.writev");
-export const _toUnixTimestamp = notImplementedAsync("fs._toUnixTimestamp");
+  /*@__PURE__*/ notImplementedAsync("fs.watchFile");
+export const write: typeof fs.write =
+  /*@__PURE__*/ notImplementedAsync("fs.write");
+export const writev: typeof fs.writev =
+  /*@__PURE__*/ notImplementedAsync("fs.writev");
+export const _toUnixTimestamp = /*@__PURE__*/ notImplementedAsync(
+  "fs._toUnixTimestamp",
+);
 export const openAsBlob: typeof fs.openAsBlob =
-  notImplementedAsync("fs.openAsBlob");
-export const glob: typeof fs.glob = notImplementedAsync("fs.glob");
+  /*@__PURE__*/ notImplementedAsync("fs.openAsBlob");
+export const glob: typeof fs.glob =
+  /*@__PURE__*/ notImplementedAsync("fs.glob");
 
 // Sync
 export const appendFileSync =

--- a/src/runtime/node/internal/fs/promises.ts
+++ b/src/runtime/node/internal/fs/promises.ts
@@ -3,57 +3,69 @@ import { notImplemented } from "../../../_internal/utils";
 
 export { constants } from "./constants";
 
-export const access = notImplemented<typeof fsp.access>("fs.access");
-export const copyFile = notImplemented<typeof fsp.copyFile>("fs.copyFile");
-export const cp = notImplemented<typeof fsp.cp>("fs.cp");
-export const open = notImplemented<typeof fsp.open>("fs.open");
-export const opendir = notImplemented<typeof fsp.opendir>("fs.opendir");
-export const rename = notImplemented<typeof fsp.rename>("fs.rename");
-export const truncate = notImplemented<typeof fsp.truncate>("fs.truncate");
-export const rm = notImplemented<typeof fsp.rm>("fs.rm");
-export const rmdir = notImplemented<typeof fsp.rmdir>("fs.rmdir");
-export const mkdir = notImplemented<typeof fsp.mkdir>(
+export const access =
+  /*@__PURE__*/ notImplemented<typeof fsp.access>("fs.access");
+export const copyFile =
+  /*@__PURE__*/ notImplemented<typeof fsp.copyFile>("fs.copyFile");
+export const cp = /*@__PURE__*/ notImplemented<typeof fsp.cp>("fs.cp");
+export const open = /*@__PURE__*/ notImplemented<typeof fsp.open>("fs.open");
+export const opendir =
+  /*@__PURE__*/ notImplemented<typeof fsp.opendir>("fs.opendir");
+export const rename =
+  /*@__PURE__*/ notImplemented<typeof fsp.rename>("fs.rename");
+export const truncate =
+  /*@__PURE__*/ notImplemented<typeof fsp.truncate>("fs.truncate");
+export const rm = /*@__PURE__*/ notImplemented<typeof fsp.rm>("fs.rm");
+export const rmdir = /*@__PURE__*/ notImplemented<typeof fsp.rmdir>("fs.rmdir");
+export const mkdir = /*@__PURE__*/ notImplemented<typeof fsp.mkdir>(
   "fs.mkdir",
 ) as typeof fsp.mkdir;
-export const readdir = notImplemented<typeof fsp.readdir>(
+export const readdir = /*@__PURE__*/ notImplemented<typeof fsp.readdir>(
   "fs.readdir",
 ) as unknown as typeof fsp.readdir;
-export const readlink = notImplemented<typeof fsp.readlink>(
+export const readlink = /*@__PURE__*/ notImplemented<typeof fsp.readlink>(
   "fs.readlink",
 ) as typeof fsp.readlink;
-export const symlink = notImplemented<typeof fsp.symlink>("fs.symlink");
-export const lstat = notImplemented<typeof fsp.lstat>(
+export const symlink =
+  /*@__PURE__*/ notImplemented<typeof fsp.symlink>("fs.symlink");
+export const lstat = /*@__PURE__*/ notImplemented<typeof fsp.lstat>(
   "fs.lstat",
 ) as typeof fsp.lstat;
-export const stat = notImplemented<typeof fsp.stat>(
+export const stat = /*@__PURE__*/ notImplemented<typeof fsp.stat>(
   "fs.stat",
 ) as typeof fsp.stat;
-export const link = notImplemented<typeof fsp.link>("fs.link");
-export const unlink = notImplemented<typeof fsp.unlink>("fs.unlink");
-export const chmod = notImplemented<typeof fsp.chmod>("fs.chmod");
-export const lchmod = notImplemented<typeof fsp.lchmod>("fs.lchmod");
-export const lchown = notImplemented<typeof fsp.lchown>("fs.lchown");
-export const chown = notImplemented<typeof fsp.chown>("fs.chown");
-export const utimes = notImplemented<typeof fsp.utimes>("fs.utimes");
-export const lutimes = notImplemented<typeof fsp.lutimes>("fs.lutimes");
-export const realpath = notImplemented<typeof fsp.realpath>(
+export const link = /*@__PURE__*/ notImplemented<typeof fsp.link>("fs.link");
+export const unlink =
+  /*@__PURE__*/ notImplemented<typeof fsp.unlink>("fs.unlink");
+export const chmod = /*@__PURE__*/ notImplemented<typeof fsp.chmod>("fs.chmod");
+export const lchmod =
+  /*@__PURE__*/ notImplemented<typeof fsp.lchmod>("fs.lchmod");
+export const lchown =
+  /*@__PURE__*/ notImplemented<typeof fsp.lchown>("fs.lchown");
+export const chown = /*@__PURE__*/ notImplemented<typeof fsp.chown>("fs.chown");
+export const utimes =
+  /*@__PURE__*/ notImplemented<typeof fsp.utimes>("fs.utimes");
+export const lutimes =
+  /*@__PURE__*/ notImplemented<typeof fsp.lutimes>("fs.lutimes");
+export const realpath = /*@__PURE__*/ notImplemented<typeof fsp.realpath>(
   "fs.realpath",
 ) as typeof fsp.realpath;
-export const mkdtemp = notImplemented<typeof fsp.mkdtemp>(
+export const mkdtemp = /*@__PURE__*/ notImplemented<typeof fsp.mkdtemp>(
   "fs.mkdtemp",
 ) as typeof fsp.mkdtemp;
-export const writeFile = notImplemented<typeof fsp.writeFile>("fs.writeFile");
+export const writeFile =
+  /*@__PURE__*/ notImplemented<typeof fsp.writeFile>("fs.writeFile");
 export const appendFile =
-  notImplemented<typeof fsp.appendFile>("fs.appendFile");
-export const readFile = notImplemented<typeof fsp.readFile>(
+  /*@__PURE__*/ notImplemented<typeof fsp.appendFile>("fs.appendFile");
+export const readFile = /*@__PURE__*/ notImplemented<typeof fsp.readFile>(
   "fs.readFile",
 ) as typeof fsp.readFile;
-export const watch = notImplemented<typeof fsp.watch>(
+export const watch = /*@__PURE__*/ notImplemented<typeof fsp.watch>(
   "fs.watch",
 ) as typeof fsp.watch;
-export const statfs = notImplemented<typeof fsp.statfs>(
+export const statfs = /*@__PURE__*/ notImplemented<typeof fsp.statfs>(
   "fs.statfs",
 ) as typeof fsp.statfs;
-export const glob = notImplemented<typeof fsp.glob>("fs.glob");
+export const glob = /*@__PURE__*/ notImplemented<typeof fsp.glob>("fs.glob");
 
 export default <typeof fsp>{};

--- a/src/runtime/node/internal/process/process.ts
+++ b/src/runtime/node/internal/process/process.ts
@@ -165,12 +165,12 @@ export const report: Exclude<Process["report"], undefined> = Object.create({
   compact: undefined,
   directory: undefined,
   filename: undefined,
-  getReport: notImplemented("process.report.getReport"),
+  getReport: /*@__PURE__*/ notImplemented("process.report.getReport"),
   reportOnFatalError: undefined,
   reportOnSignal: undefined,
   reportOnUncaughtException: undefined,
   signal: undefined,
-  writeReport: notImplemented("process.report.writeReport"),
+  writeReport: /*@__PURE__*/ notImplemented("process.report.writeReport"),
 });
 export const resourceUsage = notImplemented<Process["resourceUsage"]>(
   "process.resourceUsage",
@@ -224,28 +224,40 @@ export const finalization: Process["finalization"] = {
 
 // --- Undocumented internals ---
 
-export const assert = notImplemented("process.assert");
-export const openStdin = notImplemented("process.openStdin");
-export const _debugEnd = notImplemented("process._debugEnd");
-export const _debugProcess = notImplemented("process._debugProcess");
-export const _fatalException = notImplemented("process._fatalException");
-export const _getActiveHandles = notImplemented("process._getActiveHandles");
-export const _getActiveRequests = notImplemented("process._getActiveRequests");
-export const _kill = notImplemented("process._kill");
+export const assert = /*@__PURE__*/ notImplemented("process.assert");
+export const openStdin = /*@__PURE__*/ notImplemented("process.openStdin");
+export const _debugEnd = /*@__PURE__*/ notImplemented("process._debugEnd");
+export const _debugProcess = /*@__PURE__*/ notImplemented(
+  "process._debugProcess",
+);
+export const _fatalException = /*@__PURE__*/ notImplemented(
+  "process._fatalException",
+);
+export const _getActiveHandles = /*@__PURE__*/ notImplemented(
+  "process._getActiveHandles",
+);
+export const _getActiveRequests = /*@__PURE__*/ notImplemented(
+  "process._getActiveRequests",
+);
+export const _kill = /*@__PURE__*/ notImplemented("process._kill");
 export const _preload_modules: string[] = [];
-export const _rawDebug = notImplemented("process._rawDebug");
-export const _startProfilerIdleNotifier = notImplemented(
+export const _rawDebug = /*@__PURE__*/ notImplemented("process._rawDebug");
+export const _startProfilerIdleNotifier = /*@__PURE__*/ notImplemented(
   "process._startProfilerIdleNotifier",
 );
-export const _stopProfilerIdleNotifier = notImplemented(
+export const _stopProfilerIdleNotifier = /*@__PURE__*/ notImplemented(
   "process.__stopProfilerIdleNotifier",
 );
-export const _tickCallback = notImplemented("process._tickCallback");
-export const _linkedBinding = notImplemented("process._linkedBinding");
+export const _tickCallback = /*@__PURE__*/ notImplemented(
+  "process._tickCallback",
+);
+export const _linkedBinding = /*@__PURE__*/ notImplemented(
+  "process._linkedBinding",
+);
 
 // Mocking domain causes troubles, see unjs/unenv#367
 export const domain = undefined;
-export const initgroups = notImplemented("process.initgroups");
+export const initgroups = /*@__PURE__*/ notImplemented("process.initgroups");
 export const moduleLoadList = [] as string[];
 export const reallyExit = noop;
 

--- a/src/runtime/node/internal/process/process.ts
+++ b/src/runtime/node/internal/process/process.ts
@@ -99,7 +99,8 @@ export const getBuiltinModule = (_name: string) => undefined;
 
 // ---- Unimplemented utils ----
 
-export const abort = notImplemented<Process["abort"]>("process.abort");
+export const abort =
+  /*@__PURE__*/ notImplemented<Process["abort"]>("process.abort");
 
 export const allowedNodeEnvironmentFlags: Process["allowedNodeEnvironmentFlags"] =
   new Set();
@@ -110,16 +111,19 @@ export const config: Process["config"] = empty;
 const connected: Process["connected"] = false;
 export const constrainedMemory: Process["constrainedMemory"] = () => 0;
 export const availableMemory: Process["availableMemory"] = () => 0;
-export const cpuUsage = notImplemented<Process["cpuUsage"]>("process.cpuUsage");
+export const cpuUsage =
+  /*@__PURE__*/ notImplemented<Process["cpuUsage"]>("process.cpuUsage");
 export const debugPort: Process["debugPort"] = 0;
-export const dlopen = notImplemented<Process["dlopen"]>("process.dlopen");
+export const dlopen =
+  /*@__PURE__*/ notImplemented<Process["dlopen"]>("process.dlopen");
 const disconnect: Process["disconnect"] = noop;
 export const emitWarning: Process["emitWarning"] = noop;
 export const eventNames =
-  notImplemented<Process["eventNames"]>("process.eventNames");
+  /*@__PURE__*/ notImplemented<Process["eventNames"]>("process.eventNames");
 export const execArgv: Process["execArgv"] = [];
 export const execPath: Process["execPath"] = "";
-export const exit = notImplemented<Process["exit"]>("process.exit");
+export const exit =
+  /*@__PURE__*/ notImplemented<Process["exit"]>("process.exit");
 export const features: Process["features"] = Object.create({
   inspector: undefined,
   debug: undefined,
@@ -133,10 +137,11 @@ export const features: Process["features"] = Object.create({
 });
 export const getActiveResourcesInfo: Process["getActiveResourcesInfo"] =
   () => [];
-export const getMaxListeners = notImplemented<Process["getMaxListeners"]>(
-  "process.getMaxListeners",
-);
-export const kill = notImplemented<Process["kill"]>("process.kill");
+export const getMaxListeners = /*@__PURE__*/ notImplemented<
+  Process["getMaxListeners"]
+>("process.getMaxListeners");
+export const kill =
+  /*@__PURE__*/ notImplemented<Process["kill"]>("process.kill");
 
 export const memoryUsage: Process["memoryUsage"] = Object.assign(
   () => ({
@@ -152,9 +157,9 @@ export const memoryUsage: Process["memoryUsage"] = Object.assign(
 export const pid: Process["pid"] = 1000;
 export const platform: Process["platform"] = "" as any;
 export const ppid: Process["ppid"] = 1000;
-export const rawListeners = notImplemented<Process["rawListeners"]>(
-  "process.rawListeners",
-);
+export const rawListeners = /*@__PURE__*/ notImplemented<
+  Process["rawListeners"]
+>("process.rawListeners");
 export const release: Process["release"] = Object.create({
   name: "",
   lts: "",
@@ -172,23 +177,33 @@ export const report: Exclude<Process["report"], undefined> = Object.create({
   signal: undefined,
   writeReport: /*@__PURE__*/ notImplemented("process.report.writeReport"),
 });
-export const resourceUsage = notImplemented<Process["resourceUsage"]>(
-  "process.resourceUsage",
-);
+export const resourceUsage = /*@__PURE__*/ notImplemented<
+  Process["resourceUsage"]
+>("process.resourceUsage");
 export const setegid =
-  notImplemented<Exclude<Process["setegid"], undefined>>("process.setegid");
+  /*@__PURE__*/ notImplemented<Exclude<Process["setegid"], undefined>>(
+    "process.setegid",
+  );
 export const seteuid =
-  notImplemented<Exclude<Process["seteuid"], undefined>>("process.seteuid");
+  /*@__PURE__*/ notImplemented<Exclude<Process["seteuid"], undefined>>(
+    "process.seteuid",
+  );
 export const setgid =
-  notImplemented<Exclude<Process["setgid"], undefined>>("process.setgid");
+  /*@__PURE__*/ notImplemented<Exclude<Process["setgid"], undefined>>(
+    "process.setgid",
+  );
 export const setgroups =
-  notImplemented<Exclude<Process["setgroups"], undefined>>("process.setgroups");
+  /*@__PURE__*/ notImplemented<Exclude<Process["setgroups"], undefined>>(
+    "process.setgroups",
+  );
 export const setuid =
-  notImplemented<Exclude<Process["setuid"], undefined>>("process.setuid");
-export const setMaxListeners = notImplemented<Process["setMaxListeners"]>(
-  "process.setMaxListeners",
-);
-export const setSourceMapsEnabled = notImplemented<
+  /*@__PURE__*/ notImplemented<Exclude<Process["setuid"], undefined>>(
+    "process.setuid",
+  );
+export const setMaxListeners = /*@__PURE__*/ notImplemented<
+  Process["setMaxListeners"]
+>("process.setMaxListeners");
+export const setSourceMapsEnabled = /*@__PURE__*/ notImplemented<
   Process["setSourceMapsEnabled"]
 >("process.setSourceMapsEnabled");
 export const stdin = new ReadStream(0) as Process["stdin"];
@@ -197,13 +212,13 @@ export const stderr = new WriteStream(2) as Process["stderr"];
 const traceDeprecation: Process["traceDeprecation"] = false;
 export const uptime: Process["uptime"] = () => 0;
 export const exitCode: Process["exitCode"] = 0;
-export const setUncaughtExceptionCaptureCallback = notImplemented<
+export const setUncaughtExceptionCaptureCallback = /*@__PURE__*/ notImplemented<
   Process["setUncaughtExceptionCaptureCallback"]
 >("process.setUncaughtExceptionCaptureCallback");
 export const hasUncaughtExceptionCaptureCallback: Process["hasUncaughtExceptionCaptureCallback"] =
   () => false;
 export const sourceMapsEnabled: Process["sourceMapsEnabled"] = false;
-export const loadEnvFile = notImplemented<Process["loadEnvFile"]>(
+export const loadEnvFile = /*@__PURE__*/ notImplemented<Process["loadEnvFile"]>(
   "process.loadEnvFile",
 );
 const mainModule: Process["mainModule"] = undefined;

--- a/src/runtime/node/internal/util/types.ts
+++ b/src/runtime/node/internal/util/types.ts
@@ -6,7 +6,7 @@ export const isExternal: typeof utilTypes.isExternal = (_obj) => false;
 export const isDate: typeof utilTypes.isDate = (val): val is Date =>
   val instanceof Date;
 
-export const isArgumentsObject = notImplemented<
+export const isArgumentsObject = /*@__PURE__*/ notImplemented<
   typeof utilTypes.isArgumentsObject
 >("util.types.isArgumentsObject");
 
@@ -29,22 +29,22 @@ export const isSymbolObject: typeof utilTypes.isSymbolObject = (
   val,
 ): val is symbol => val instanceof Symbol;
 
-export const isNativeError = notImplemented<typeof utilTypes.isNativeError>(
-  "util.types.isNativeError",
-);
+export const isNativeError = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isNativeError
+>("util.types.isNativeError");
 
 export const isRegExp: typeof utilTypes.isRegExp = (val): val is RegExp =>
   val instanceof RegExp;
 
-export const isAsyncFunction = notImplemented<typeof utilTypes.isAsyncFunction>(
-  "util.types.isAsyncFunction",
-);
+export const isAsyncFunction = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isAsyncFunction
+>("util.types.isAsyncFunction");
 
-export const isGeneratorFunction = notImplemented<
+export const isGeneratorFunction = /*@__PURE__*/ notImplemented<
   typeof utilTypes.isGeneratorFunction
 >("util.types.isGeneratorFunction");
 
-export const isGeneratorObject = notImplemented<
+export const isGeneratorObject = /*@__PURE__*/ notImplemented<
   typeof utilTypes.isGeneratorObject
 >("util.types.isGeneratorObject");
 
@@ -60,13 +60,13 @@ export const isMap: typeof utilTypes.isMap = (val): val is Map =>
 export const isSet: typeof utilTypes.isSet = (val): val is Set =>
   val instanceof Set;
 
-export const isMapIterator = notImplemented<typeof utilTypes.isMapIterator>(
-  "util.types.isMapIterator",
-);
+export const isMapIterator = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isMapIterator
+>("util.types.isMapIterator");
 
-export const isSetIterator = notImplemented<typeof utilTypes.isSetIterator>(
-  "util.types.isSetIterator",
-);
+export const isSetIterator = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isSetIterator
+>("util.types.isSetIterator");
 
 // @ts-ignore
 export const isWeakMap: typeof utilTypes.isWeakMap = (val): val is WeakMap =>
@@ -88,76 +88,76 @@ export const isSharedArrayBuffer: typeof utilTypes.isSharedArrayBuffer = (
 ): val is SharedArrayBuffer => val instanceof SharedArrayBuffer;
 
 export const isProxy =
-  notImplemented<typeof utilTypes.isProxy>("util.types.isProxy");
+  /*@__PURE__*/ notImplemented<typeof utilTypes.isProxy>("util.types.isProxy");
 
-export const isModuleNamespaceObject = notImplemented<
+export const isModuleNamespaceObject = /*@__PURE__*/ notImplemented<
   typeof utilTypes.isModuleNamespaceObject
 >("util.types.isModuleNamespaceObject");
 
-export const isAnyArrayBuffer = notImplemented<
+export const isAnyArrayBuffer = /*@__PURE__*/ notImplemented<
   typeof utilTypes.isAnyArrayBuffer
 >("util.types.isAnyArrayBuffer");
 
-export const isBoxedPrimitive = notImplemented<
+export const isBoxedPrimitive = /*@__PURE__*/ notImplemented<
   typeof utilTypes.isBoxedPrimitive
 >("util.types.isBoxedPrimitive");
 
-export const isArrayBufferView = notImplemented<
+export const isArrayBufferView = /*@__PURE__*/ notImplemented<
   typeof utilTypes.isArrayBufferView
 >("util.types.isArrayBufferView");
 
-export const isTypedArray = notImplemented<typeof utilTypes.isTypedArray>(
-  "util.types.isTypedArray",
-);
+export const isTypedArray = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isTypedArray
+>("util.types.isTypedArray");
 
-export const isUint8Array = notImplemented<typeof utilTypes.isUint8Array>(
-  "util.types.isUint8Array",
-);
+export const isUint8Array = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isUint8Array
+>("util.types.isUint8Array");
 
-export const isUint8ClampedArray = notImplemented<
+export const isUint8ClampedArray = /*@__PURE__*/ notImplemented<
   typeof utilTypes.isUint8ClampedArray
 >("util.types.isUint8ClampedArray");
 
-export const isUint16Array = notImplemented<typeof utilTypes.isUint16Array>(
-  "util.types.isUint16Array",
-);
+export const isUint16Array = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isUint16Array
+>("util.types.isUint16Array");
 
-export const isUint32Array = notImplemented<typeof utilTypes.isUint32Array>(
-  "util.types.isUint32Array",
-);
+export const isUint32Array = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isUint32Array
+>("util.types.isUint32Array");
 
-export const isInt8Array = notImplemented<typeof utilTypes.isInt8Array>(
-  "util.types.isInt8Array",
-);
+export const isInt8Array = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isInt8Array
+>("util.types.isInt8Array");
 
-export const isInt16Array = notImplemented<typeof utilTypes.isInt16Array>(
-  "util.types.isInt16Array",
-);
+export const isInt16Array = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isInt16Array
+>("util.types.isInt16Array");
 
-export const isInt32Array = notImplemented<typeof utilTypes.isInt32Array>(
-  "util.types.isInt32Array",
-);
+export const isInt32Array = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isInt32Array
+>("util.types.isInt32Array");
 
-export const isFloat32Array = notImplemented<typeof utilTypes.isFloat32Array>(
-  "util.types.isFloat32Array",
-);
+export const isFloat32Array = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isFloat32Array
+>("util.types.isFloat32Array");
 
-export const isFloat64Array = notImplemented<typeof utilTypes.isFloat64Array>(
-  "util.types.isFloat64Array",
-);
+export const isFloat64Array = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isFloat64Array
+>("util.types.isFloat64Array");
 
-export const isBigInt64Array = notImplemented<typeof utilTypes.isBigInt64Array>(
-  "util.types.isBigInt64Array",
-);
+export const isBigInt64Array = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isBigInt64Array
+>("util.types.isBigInt64Array");
 
-export const isBigUint64Array = notImplemented<
+export const isBigUint64Array = /*@__PURE__*/ notImplemented<
   typeof utilTypes.isBigUint64Array
 >("util.types.isBigUint64Array");
 
-export const isKeyObject = notImplemented<typeof utilTypes.isKeyObject>(
-  "util.types.isKeyObject",
-);
+export const isKeyObject = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isKeyObject
+>("util.types.isKeyObject");
 
-export const isCryptoKey = notImplemented<typeof utilTypes.isCryptoKey>(
-  "util.types.isCryptoKey",
-);
+export const isCryptoKey = /*@__PURE__*/ notImplemented<
+  typeof utilTypes.isCryptoKey
+>("util.types.isCryptoKey");

--- a/src/runtime/node/internal/zlib/formats/brotli.ts
+++ b/src/runtime/node/internal/zlib/formats/brotli.ts
@@ -19,7 +19,7 @@ export const createBrotliCompress: typeof zlib.createBrotliCompress = () =>
   new BrotliCompress();
 
 export const brotliCompressSync: typeof zlib.brotliCompressSync =
-  notImplemented("zlib.brotliCompressSync");
+  /*@__PURE__*/ notImplemented("zlib.brotliCompressSync");
 
 // Brotli Decompression
 
@@ -34,4 +34,4 @@ export const createBrotliDecompress: typeof zlib.createBrotliDecompress = () =>
   new BrotliDecompress();
 
 export const brotliDecompressSync: typeof zlib.brotliDecompressSync =
-  notImplemented("zlib.brotliDecompressSync");
+  /*@__PURE__*/ notImplemented("zlib.brotliDecompressSync");

--- a/src/runtime/node/internal/zlib/formats/deflate.ts
+++ b/src/runtime/node/internal/zlib/formats/deflate.ts
@@ -25,7 +25,7 @@ export const deflate: typeof zlib.deflate = notImplementedCompress("deflate");
 export const createDeflate: typeof zlib.createDeflate = () => new Deflate();
 
 export const deflateSync: typeof zlib.deflateSync =
-  notImplemented("zlib.deflateSync");
+  /*@__PURE__*/ notImplemented("zlib.deflateSync");
 
 // Deflate Decompress(Inflate)
 
@@ -42,7 +42,7 @@ export const inflate: typeof zlib.inflate = notImplementedCompress("inflate");
 export const createInflate: typeof zlib.createInflate = () => new Inflate();
 
 export const inflateSync: typeof zlib.inflateSync =
-  notImplemented("zlib.inflateSync");
+  /*@__PURE__*/ notImplemented("zlib.inflateSync");
 
 // Deflate Raw Compression
 
@@ -54,9 +54,8 @@ export const deflateRaw: typeof zlib.deflateRaw =
 export const createDeflateRaw: typeof zlib.createDeflateRaw = () =>
   new DeflateRaw();
 
-export const deflateRawSync: typeof zlib.deflateRawSync = notImplemented(
-  "zlib.deflateRawSync",
-);
+export const deflateRawSync: typeof zlib.deflateRawSync =
+  /*@__PURE__*/ notImplemented("zlib.deflateRawSync");
 
 // Inflate Raw Decompress (Inflate Raw)
 
@@ -68,6 +67,5 @@ export const inflateRaw: typeof zlib.inflateRaw =
 export const createInflateRaw: typeof zlib.createInflateRaw = () =>
   new InflateRaw();
 
-export const inflateRawSync: typeof zlib.inflateRawSync = notImplemented(
-  "zlib.inflateRawSync",
-);
+export const inflateRawSync: typeof zlib.inflateRawSync =
+  /*@__PURE__*/ notImplemented("zlib.inflateRawSync");

--- a/src/runtime/node/internal/zlib/formats/gzip.ts
+++ b/src/runtime/node/internal/zlib/formats/gzip.ts
@@ -16,7 +16,8 @@ export const gzip: typeof zlib.gzip = notImplementedCompress("gzip");
 
 export const createGzip: typeof zlib.createGzip = () => new Gzip();
 
-export const gzipSync: typeof zlib.gzipSync = notImplemented("zlib.gzipSync");
+export const gzipSync: typeof zlib.gzipSync =
+  /*@__PURE__*/ notImplemented("zlib.gzipSync");
 
 // Gzip Decompression
 
@@ -29,4 +30,4 @@ export const gunzip: typeof zlib.gunzip = notImplementedCompress("gunzip");
 export const createGunzip: typeof zlib.createGunzip = () => new Gunzip();
 
 export const gunzipSync: typeof zlib.gunzipSync =
-  notImplemented("zlib.gunzipSync");
+  /*@__PURE__*/ notImplemented("zlib.gunzipSync");

--- a/src/runtime/node/internal/zlib/formats/zip.ts
+++ b/src/runtime/node/internal/zlib/formats/zip.ts
@@ -10,7 +10,8 @@ export class Unzip extends ZlibCompress {
 
 export const createUnzip: typeof zlib.createUnzip = () => new Unzip();
 
-export const unzip: typeof zlib.unzip = notImplemented("zlib.unzip");
+export const unzip: typeof zlib.unzip =
+  /*@__PURE__*/ notImplemented("zlib.unzip");
 
 export const unzipSync: typeof zlib.unzipSync =
-  notImplemented("zlib.unzipSync");
+  /*@__PURE__*/ notImplemented("zlib.unzipSync");

--- a/src/runtime/node/module.ts
+++ b/src/runtime/node/module.ts
@@ -105,7 +105,7 @@ export const wrap: typeof nodeModule.wrap = function (source) {
 };
 
 export const stripTypeScriptTypes: typeof nodeModule.stripTypeScriptTypes =
-  notImplemented<typeof nodeModule.stripTypeScriptTypes>(
+  /*@__PURE__*/ notImplemented<typeof nodeModule.stripTypeScriptTypes>(
     "module.stripTypeScriptTypes",
   );
 

--- a/src/runtime/node/module.ts
+++ b/src/runtime/node/module.ts
@@ -5,16 +5,19 @@ import { notImplemented, notImplementedClass } from "../_internal/utils";
 export const _cache = Object.create(null);
 
 export const _extensions = {
-  ".js": notImplemented("module.require.extensions['.js']"),
-  ".json": notImplemented("module.require.extensions['.json']"),
-  ".node": notImplemented("module.require.extensions['.node']"),
+  ".js": /*@__PURE__*/ notImplemented("module.require.extensions['.js']"),
+  ".json": /*@__PURE__*/ notImplemented("module.require.extensions['.json']"),
+  ".node": /*@__PURE__*/ notImplemented("module.require.extensions['.node']"),
 };
 
 export const createRequire = function (_filename: string | URL) {
-  return Object.assign(notImplemented("module.require"), {
-    resolve: Object.assign(notImplemented("module.require.resolve"), {
-      paths: notImplemented("module.require.resolve.paths"),
-    }),
+  return Object.assign(/*@__PURE__*/ notImplemented("module.require"), {
+    resolve: Object.assign(
+      /*@__PURE__*/ notImplemented("module.require.resolve"),
+      {
+        paths: /*@__PURE__*/ notImplemented("module.require.resolve.paths"),
+      },
+    ),
     cache: Object.create(null),
     extensions: _extensions,
     main: undefined,
@@ -75,10 +78,10 @@ export const isBuiltin: typeof nodeModule.isBuiltin = function (id) {
 };
 
 export const runMain: typeof nodeModule.runMain =
-  notImplemented("module.runMain");
+  /*@__PURE__*/ notImplemented("module.runMain");
 
 export const register: typeof nodeModule.register =
-  notImplemented("module.register");
+  /*@__PURE__*/ notImplemented("module.register");
 
 export const syncBuiltinESMExports: typeof nodeModule.syncBuiltinESMExports =
   function () {
@@ -106,19 +109,27 @@ export const stripTypeScriptTypes: typeof nodeModule.stripTypeScriptTypes =
     "module.stripTypeScriptTypes",
   );
 
-export const SourceMap = notImplementedClass(
+export const SourceMap = /*@__PURE__*/ notImplementedClass(
   "module.SourceMap",
 ) as typeof nodeModule.SourceMap;
 
 export const _debug = console.debug;
 
-export const _findPath = notImplemented("module._findPath");
-export const _initPaths = notImplemented("module._initPaths");
-export const _load = notImplemented("module._load");
-export const _nodeModulePaths = notImplemented("module._nodeModulePaths");
-export const _preloadModules = notImplemented("module._preloadModules");
-export const _resolveFilename = notImplemented("module._resolveFilename");
-export const _resolveLookupPaths = notImplemented("module._resolveLookupPaths");
+export const _findPath = /*@__PURE__*/ notImplemented("module._findPath");
+export const _initPaths = /*@__PURE__*/ notImplemented("module._initPaths");
+export const _load = /*@__PURE__*/ notImplemented("module._load");
+export const _nodeModulePaths = /*@__PURE__*/ notImplemented(
+  "module._nodeModulePaths",
+);
+export const _preloadModules = /*@__PURE__*/ notImplemented(
+  "module._preloadModules",
+);
+export const _resolveFilename = /*@__PURE__*/ notImplemented(
+  "module._resolveFilename",
+);
+export const _resolveLookupPaths = /*@__PURE__*/ notImplemented(
+  "module._resolveLookupPaths",
+);
 
 export const _pathCache = Object.create(null);
 export const globalPaths = ["node_modules"];

--- a/src/runtime/node/net.ts
+++ b/src/runtime/node/net.ts
@@ -11,35 +11,39 @@ export { Server } from "./internal/net/server";
 // require('node:net').Socket === require('node:net').Stream
 export { Socket, SocketAddress, Socket as Stream } from "./internal/net/socket";
 
-export const createServer = notImplemented(
+export const createServer = /*@__PURE__*/ notImplemented(
   "net.createServer",
 ) as typeof net.createServer;
 
-export const BlockList = notImplementedClass(
+export const BlockList = /*@__PURE__*/ notImplementedClass(
   "net.BlockList",
 ) as typeof net.BlockList;
 
-export const connect = notImplemented("net.connect") as typeof net.connect;
+export const connect = /*@__PURE__*/ notImplemented(
+  "net.connect",
+) as typeof net.connect;
 
-export const createConnection = notImplemented(
+export const createConnection = /*@__PURE__*/ notImplemented(
   "net.createConnection",
 ) as typeof net.createConnection;
 
-export const getDefaultAutoSelectFamily = notImplemented(
+export const getDefaultAutoSelectFamily = /*@__PURE__*/ notImplemented(
   "net.getDefaultAutoSelectFamily",
 ) as typeof net.getDefaultAutoSelectFamily;
 
-export const setDefaultAutoSelectFamily = notImplemented(
+export const setDefaultAutoSelectFamily = /*@__PURE__*/ notImplemented(
   "net.setDefaultAutoSelectFamily",
 ) as typeof net.setDefaultAutoSelectFamily;
 
-export const getDefaultAutoSelectFamilyAttemptTimeout = notImplemented(
-  "net.getDefaultAutoSelectFamilyAttemptTimeout",
-) as typeof net.getDefaultAutoSelectFamilyAttemptTimeout;
+export const getDefaultAutoSelectFamilyAttemptTimeout =
+  /*@__PURE__*/ notImplemented(
+    "net.getDefaultAutoSelectFamilyAttemptTimeout",
+  ) as typeof net.getDefaultAutoSelectFamilyAttemptTimeout;
 
-export const setDefaultAutoSelectFamilyAttemptTimeout = notImplemented(
-  "net.setDefaultAutoSelectFamilyAttemptTimeout",
-) as typeof net.setDefaultAutoSelectFamilyAttemptTimeout;
+export const setDefaultAutoSelectFamilyAttemptTimeout =
+  /*@__PURE__*/ notImplemented(
+    "net.setDefaultAutoSelectFamilyAttemptTimeout",
+  ) as typeof net.setDefaultAutoSelectFamilyAttemptTimeout;
 
 const IPV4Regex = /^(?:\d{1,3}\.){3}\d{1,3}$/;
 export const isIPv4: typeof net.isIPv4 = (host: string) => IPV4Regex.test(host);
@@ -58,11 +62,14 @@ export const isIP: typeof net.isIP = (host: string) => {
 };
 
 // --- internal ---
-export const _createServerHandle = notImplemented("net._createServerHandle");
+export const _createServerHandle = /*@__PURE__*/ notImplemented(
+  "net._createServerHandle",
+);
 
-export const _normalizeArgs = notImplemented("net._normalizeArgs");
+export const _normalizeArgs =
+  /*@__PURE__*/ notImplemented("net._normalizeArgs");
 
-export const _setSimultaneousAccepts = notImplemented(
+export const _setSimultaneousAccepts = /*@__PURE__*/ notImplemented(
   "net._setSimultaneousAccepts",
 );
 

--- a/src/runtime/node/os.ts
+++ b/src/runtime/node/os.ts
@@ -29,7 +29,7 @@ export const cpus: typeof os.cpus = () => {
 
 export const getPriority: typeof os.getPriority = () => 0;
 export const setPriority: typeof os.setPriority =
-  notImplemented<typeof os.setPriority>("os.setPriority");
+  /*@__PURE__*/ notImplemented<typeof os.setPriority>("os.setPriority");
 
 export const homedir: typeof os.homedir = () => "/";
 export const tmpdir: typeof os.tmpdir = () => "/tmp";

--- a/src/runtime/node/path.ts
+++ b/src/runtime/node/path.ts
@@ -14,7 +14,7 @@ const _pathModule = {
   win32: undefined as any,
   _makeLong: (path: string) => path,
   // https://github.com/unjs/pathe/issues/182
-  matchesGlob: notImplemented(`path.matchesGlob`),
+  matchesGlob: /*@__PURE__*/ notImplemented(`path.matchesGlob`),
 };
 _pathModule.posix = _pathModule;
 _pathModule.win32 = _pathModule;

--- a/src/runtime/node/stream.ts
+++ b/src/runtime/node/stream.ts
@@ -18,15 +18,15 @@ export const Stream: stream.Stream = mock.__createMock__("Stream");
 export const PassThrough: stream.PassThrough =
   mock.__createMock__("PassThrough");
 
-export const pipeline = notImplemented<typeof stream.pipeline>(
+export const pipeline = /*@__PURE__*/ notImplemented<typeof stream.pipeline>(
   "stream.pipeline",
 ) as any;
-export const finished = notImplemented<typeof stream.finished>(
+export const finished = /*@__PURE__*/ notImplemented<typeof stream.finished>(
   "stream.finished",
 ) as any;
-export const addAbortSignal = notImplemented<typeof stream.addAbortSignal>(
-  "stream.addAbortSignal",
-);
+export const addAbortSignal = /*@__PURE__*/ notImplemented<
+  typeof stream.addAbortSignal
+>("stream.addAbortSignal");
 
 // Internal
 interface StreamInternal {

--- a/src/runtime/node/stream.ts
+++ b/src/runtime/node/stream.ts
@@ -38,13 +38,17 @@ interface StreamInternal {
   _isUint8Array: any;
   _uint8ArrayToBuffer: any;
 }
-export const isDisturbed = notImplemented("stream.isDisturbed");
-export const isReadable = notImplemented("stream.isReadable");
-export const compose = notImplemented("stream.compose");
-export const isErrored = notImplemented("stream.isErrored");
-export const destroy = notImplemented("stream.destroy");
-export const _isUint8Array = notImplemented("stream._isUint8Array");
-export const _uint8ArrayToBuffer = notImplemented("stream._uint8ArrayToBuffer");
+export const isDisturbed = /*@__PURE__*/ notImplemented("stream.isDisturbed");
+export const isReadable = /*@__PURE__*/ notImplemented("stream.isReadable");
+export const compose = /*@__PURE__*/ notImplemented("stream.compose");
+export const isErrored = /*@__PURE__*/ notImplemented("stream.isErrored");
+export const destroy = /*@__PURE__*/ notImplemented("stream.destroy");
+export const _isUint8Array = /*@__PURE__*/ notImplemented(
+  "stream._isUint8Array",
+);
+export const _uint8ArrayToBuffer = /*@__PURE__*/ notImplemented(
+  "stream._uint8ArrayToBuffer",
+);
 
 export default <typeof stream & StreamInternal>{
   Readable: Readable as unknown as typeof stream.Readable,

--- a/src/runtime/node/stream/consumers.ts
+++ b/src/runtime/node/stream/consumers.ts
@@ -1,11 +1,13 @@
 import type * as streamConsumers from "node:stream/consumers";
 import { notImplemented } from "../../_internal/utils";
 
-export const arrayBuffer = notImplemented("stream.consumers.arrayBuffer");
-export const blob = notImplemented("stream.consumers.blob");
-export const buffer = notImplemented("stream.consumers.buffer");
-export const text = notImplemented("stream.consumers.text");
-export const json = notImplemented("stream.consumers.json");
+export const arrayBuffer = /*@__PURE__*/ notImplemented(
+  "stream.consumers.arrayBuffer",
+);
+export const blob = /*@__PURE__*/ notImplemented("stream.consumers.blob");
+export const buffer = /*@__PURE__*/ notImplemented("stream.consumers.buffer");
+export const text = /*@__PURE__*/ notImplemented("stream.consumers.text");
+export const json = /*@__PURE__*/ notImplemented("stream.consumers.json");
 
 export default <typeof streamConsumers>{
   arrayBuffer,

--- a/src/runtime/node/stream/promises.ts
+++ b/src/runtime/node/stream/promises.ts
@@ -1,8 +1,12 @@
 import type * as streamPromises from "node:stream/promises";
 import { notImplemented } from "../../_internal/utils";
 
-export const finished = notImplemented("stream.promises.finished");
-export const pipeline = notImplemented("stream.promises.pipeline");
+export const finished = /*@__PURE__*/ notImplemented(
+  "stream.promises.finished",
+);
+export const pipeline = /*@__PURE__*/ notImplemented(
+  "stream.promises.pipeline",
+);
 
 export default <typeof streamPromises>{
   finished,

--- a/src/runtime/node/stream/web.ts
+++ b/src/runtime/node/stream/web.ts
@@ -2,56 +2,59 @@ import type * as streamWeb from "node:stream/web";
 import { notImplemented } from "../../_internal/utils";
 
 export const ReadableStream =
-  globalThis.ReadableStream || notImplemented("stream.web.ReadableStream");
+  globalThis.ReadableStream ||
+  /*@__PURE__*/ notImplemented("stream.web.ReadableStream");
 export const ReadableStreamDefaultReader =
   globalThis.ReadableStreamDefaultReader ||
-  notImplemented("stream.web.ReadableStreamDefaultReader");
+  /*@__PURE__*/ notImplemented("stream.web.ReadableStreamDefaultReader");
 // @ts-ignore
 export const ReadableStreamBYOBReader =
   globalThis.ReadableStreamBYOBReader ||
-  notImplemented("stream.web.ReadableStreamBYOBReader");
+  /*@__PURE__*/ notImplemented("stream.web.ReadableStreamBYOBReader");
 // @ts-ignore
 export const ReadableStreamBYOBRequest =
   globalThis.ReadableStreamBYOBRequest ||
-  notImplemented("stream.web.ReadableStreamBYOBRequest");
+  /*@__PURE__*/ notImplemented("stream.web.ReadableStreamBYOBRequest");
 // @ts-ignore
 export const ReadableByteStreamController =
   globalThis.ReadableByteStreamController ||
-  notImplemented("stream.web.ReadableByteStreamController");
+  /*@__PURE__*/ notImplemented("stream.web.ReadableByteStreamController");
 export const ReadableStreamDefaultController =
   globalThis.ReadableStreamDefaultController ||
-  notImplemented("stream.web.ReadableStreamDefaultController");
+  /*@__PURE__*/ notImplemented("stream.web.ReadableStreamDefaultController");
 export const TransformStream =
-  globalThis.TransformStream || notImplemented("stream.web.TransformStream");
+  globalThis.TransformStream ||
+  /*@__PURE__*/ notImplemented("stream.web.TransformStream");
 export const TransformStreamDefaultController =
   globalThis.TransformStreamDefaultController ||
-  notImplemented("stream.web.TransformStreamDefaultController");
+  /*@__PURE__*/ notImplemented("stream.web.TransformStreamDefaultController");
 export const WritableStream =
-  globalThis.WritableStream || notImplemented("stream.web.WritableStream");
+  globalThis.WritableStream ||
+  /*@__PURE__*/ notImplemented("stream.web.WritableStream");
 export const WritableStreamDefaultWriter =
   globalThis.WritableStreamDefaultWriter ||
-  notImplemented("stream.web.WritableStreamDefaultWriter");
+  /*@__PURE__*/ notImplemented("stream.web.WritableStreamDefaultWriter");
 export const WritableStreamDefaultController =
   globalThis.WritableStreamDefaultController ||
-  notImplemented("stream.web.WritableStreamDefaultController");
+  /*@__PURE__*/ notImplemented("stream.web.WritableStreamDefaultController");
 export const ByteLengthQueuingStrategy =
   globalThis.ByteLengthQueuingStrategy ||
-  notImplemented("stream.web.ByteLengthQueuingStrategy");
+  /*@__PURE__*/ notImplemented("stream.web.ByteLengthQueuingStrategy");
 export const CountQueuingStrategy =
   globalThis.CountQueuingStrategy ||
-  notImplemented("stream.web.CountQueuingStrategy");
+  /*@__PURE__*/ notImplemented("stream.web.CountQueuingStrategy");
 export const TextEncoderStream =
   globalThis.TextEncoderStream ||
-  notImplemented("stream.web.TextEncoderStream");
+  /*@__PURE__*/ notImplemented("stream.web.TextEncoderStream");
 export const TextDecoderStream =
   globalThis.TextDecoderStream ||
-  notImplemented("stream.web.TextDecoderStream");
+  /*@__PURE__*/ notImplemented("stream.web.TextDecoderStream");
 export const DecompressionStream =
   globalThis.DecompressionStream ||
-  notImplemented("stream.web.DecompressionStream");
+  /*@__PURE__*/ notImplemented("stream.web.DecompressionStream");
 export const CompressionStream =
   globalThis.DecompressionStream ||
-  notImplemented("stream.web.CompressionStream");
+  /*@__PURE__*/ notImplemented("stream.web.CompressionStream");
 
 // @ts-ignore
 export default <typeof streamWeb>{

--- a/src/runtime/node/string_decoder.ts
+++ b/src/runtime/node/string_decoder.ts
@@ -4,7 +4,7 @@ import { notImplementedClass } from "../_internal/utils";
 
 export const StringDecoder: typeof stringDecoder.StringDecoder =
   (globalThis as any).StringDecoder ||
-  notImplementedClass("string_decoder.StringDecoder");
+  /*@__PURE__*/ notImplementedClass("string_decoder.StringDecoder");
 
 export default <typeof stringDecoder>{
   StringDecoder,

--- a/src/runtime/node/timers.ts
+++ b/src/runtime/node/timers.ts
@@ -29,8 +29,8 @@ export const active = function active(timeout: NodeJS.Timeout | undefined) {
   timeout?.refresh?.();
 };
 export const _unrefActive = active;
-export const enroll = notImplemented("timers.enroll");
-export const unenroll = notImplemented("timers.unenroll");
+export const enroll = /*@__PURE__*/ notImplemented("timers.enroll");
+export const unenroll = /*@__PURE__*/ notImplemented("timers.unenroll");
 
 export default {
   // @ts-expect-error deprecated

--- a/src/runtime/node/tls.ts
+++ b/src/runtime/node/tls.ts
@@ -18,15 +18,16 @@ export const createServer: typeof tls.createServer = function createServer() {
   return new Server();
 };
 export const checkServerIdentity: typeof tls.checkServerIdentity =
-  notImplemented("tls.checkServerIdentity");
-export const convertALPNProtocols = notImplemented("tls.convertALPNProtocols");
-export const createSecureContext: typeof tls.createSecureContext =
-  notImplemented("tls.createSecureContext");
-export const createSecurePair: typeof tls.createSecurePair = notImplemented(
-  "tls.createSecurePair",
+  /*@__PURE__*/ notImplemented("tls.checkServerIdentity");
+export const convertALPNProtocols = /*@__PURE__*/ notImplemented(
+  "tls.convertALPNProtocols",
 );
+export const createSecureContext: typeof tls.createSecureContext =
+  /*@__PURE__*/ notImplemented("tls.createSecureContext");
+export const createSecurePair: typeof tls.createSecurePair =
+  /*@__PURE__*/ notImplemented("tls.createSecurePair");
 export const getCiphers: typeof tls.getCiphers =
-  notImplemented("tls.getCiphers");
+  /*@__PURE__*/ notImplemented("tls.getCiphers");
 
 export const rootCertificates: typeof tls.rootCertificates = [];
 

--- a/src/runtime/node/util.ts
+++ b/src/runtime/node/util.ts
@@ -24,11 +24,13 @@ export const TextEncoder: typeof util.TextEncoder = globalThis.TextEncoder;
 
 export const deprecate: typeof util.deprecate = (fn) => fn;
 
-export const _errnoException = notImplemented("util._errnoException");
-export const _exceptionWithHostPort = notImplemented(
+export const _errnoException = /*@__PURE__*/ notImplemented(
+  "util._errnoException",
+);
+export const _exceptionWithHostPort = /*@__PURE__*/ notImplemented(
   "util._exceptionWithHostPort",
 );
-export const _extend = notImplemented("util._extend");
+export const _extend = /*@__PURE__*/ notImplemented("util._extend");
 
 export const aborted = notImplemented<typeof util.aborted>("util.aborted");
 export const callbackify =
@@ -60,7 +62,7 @@ export const styleText =
   notImplemented<typeof util.styleText>("util.styleText");
 
 /** @deprecated */
-export const getCallSite = notImplemented("util.getCallSite");
+export const getCallSite = /*@__PURE__*/ notImplemented("util.getCallSite");
 
 export const getCallSites =
   notImplemented<typeof util.getCallSites>("util.getCallSites");

--- a/src/runtime/node/util.ts
+++ b/src/runtime/node/util.ts
@@ -32,42 +32,44 @@ export const _exceptionWithHostPort = /*@__PURE__*/ notImplemented(
 );
 export const _extend = /*@__PURE__*/ notImplemented("util._extend");
 
-export const aborted = notImplemented<typeof util.aborted>("util.aborted");
+export const aborted =
+  /*@__PURE__*/ notImplemented<typeof util.aborted>("util.aborted");
 export const callbackify =
-  notImplemented<typeof util.callbackify>("util.callbackify");
-export const getSystemErrorMap = notImplemented<typeof util.getSystemErrorMap>(
-  "util.getSystemErrorMap",
-);
-export const getSystemErrorName = notImplemented<
+  /*@__PURE__*/ notImplemented<typeof util.callbackify>("util.callbackify");
+export const getSystemErrorMap = /*@__PURE__*/ notImplemented<
+  typeof util.getSystemErrorMap
+>("util.getSystemErrorMap");
+export const getSystemErrorName = /*@__PURE__*/ notImplemented<
   typeof util.getSystemErrorName
 >("util.getSystemErrorName");
 export const toUSVString =
-  notImplemented<typeof util.toUSVString>("util.toUSVString");
-export const stripVTControlCharacters = notImplemented<
+  /*@__PURE__*/ notImplemented<typeof util.toUSVString>("util.toUSVString");
+export const stripVTControlCharacters = /*@__PURE__*/ notImplemented<
   typeof util.stripVTControlCharacters
 >("util.stripVTControlCharacters");
 
-export const transferableAbortController = notImplemented<
+export const transferableAbortController = /*@__PURE__*/ notImplemented<
   typeof util.transferableAbortController
 >("util.transferableAbortController");
-export const transferableAbortSignal = notImplemented<
+export const transferableAbortSignal = /*@__PURE__*/ notImplemented<
   typeof util.transferableAbortSignal
 >("util.transferableAbortSignal");
 export const parseArgs =
-  notImplemented<typeof util.parseArgs>("util.parseArgs");
+  /*@__PURE__*/ notImplemented<typeof util.parseArgs>("util.parseArgs");
 
-export const parseEnv = notImplemented<typeof util.parseEnv>("util.parseEnv");
+export const parseEnv =
+  /*@__PURE__*/ notImplemented<typeof util.parseEnv>("util.parseEnv");
 
 export const styleText =
-  notImplemented<typeof util.styleText>("util.styleText");
+  /*@__PURE__*/ notImplemented<typeof util.styleText>("util.styleText");
 
 /** @deprecated */
 export const getCallSite = /*@__PURE__*/ notImplemented("util.getCallSite");
 
 export const getCallSites =
-  notImplemented<typeof util.getCallSites>("util.getCallSites");
+  /*@__PURE__*/ notImplemented<typeof util.getCallSites>("util.getCallSites");
 
-export const getSystemErrorMessage = notImplemented<
+export const getSystemErrorMessage = /*@__PURE__*/ notImplemented<
   typeof util.getSystemErrorMessage
 >("util.getSystemErrorMessage");
 

--- a/src/runtime/node/vm.ts
+++ b/src/runtime/node/vm.ts
@@ -7,7 +7,7 @@ export { Script } from "./internal/vm/script";
 export * as constants from "./internal/vm/constants";
 
 export const compileFunction: typeof vm.compileFunction =
-  notImplemented("vm.compileFunction");
+  /*@__PURE__*/ notImplemented("vm.compileFunction");
 
 const _contextSymbol = Symbol("uenv.vm.context");
 
@@ -34,14 +34,13 @@ export const measureMemory: typeof vm.measureMemory = () =>
   });
 
 export const runInContext: typeof vm.runInContext =
-  notImplemented("vm.runInContext");
+  /*@__PURE__*/ notImplemented("vm.runInContext");
 
 export const runInNewContext: typeof vm.runInNewContext =
-  notImplemented("vm.runInNewContext");
+  /*@__PURE__*/ notImplemented("vm.runInNewContext");
 
-export const runInThisContext: typeof vm.runInThisContext = notImplemented(
-  "vm.runInThisContext",
-);
+export const runInThisContext: typeof vm.runInThisContext =
+  /*@__PURE__*/ notImplemented("vm.runInThisContext");
 
 export default <
   Omit<typeof vm, "Module" | "SourceTextModule" | "SyntheticModule">

--- a/src/runtime/node/wasi.ts
+++ b/src/runtime/node/wasi.ts
@@ -1,7 +1,8 @@
 import type wasi from "node:wasi";
 import { notImplementedClass } from "../_internal/utils";
 
-export const WASI: typeof wasi.WASI = notImplementedClass("wasi.WASI");
+export const WASI: typeof wasi.WASI =
+  /*@__PURE__*/ notImplementedClass("wasi.WASI");
 
 export default {
   WASI,

--- a/src/runtime/node/worker_threads.ts
+++ b/src/runtime/node/worker_threads.ts
@@ -53,7 +53,7 @@ export const threadId: typeof worker_threads.threadId = 0;
 export const workerData: typeof worker_threads.workerData = null;
 
 // https://nodejs.org/api/worker_threads.html#workerpostmessagetothreadthreadid-value-transferlist-timeout
-export const postMessageToThread = notImplemented(
+export const postMessageToThread = /*@__PURE__*/ notImplemented(
   "worker_threads.postMessageToThread",
 );
 

--- a/src/runtime/npm/whatwg-url.ts
+++ b/src/runtime/npm/whatwg-url.ts
@@ -4,22 +4,34 @@ import { notImplemented } from "../_internal/utils";
 export const URL = globalThis.URL;
 export const URLSearchParams = globalThis.URLSearchParams;
 
-export const parseURL = notImplemented("whatwg-url.parseURL");
-export const basicURLParse = notImplemented("whatwg-url.basicURLParse");
-export const serializeURL = notImplemented("whatwg-url.serializeURL");
-export const serializeHost = notImplemented("whatwg-url.serializeHost");
-export const serializeInteger = notImplemented("whatwg-url.serializeInteger");
-export const serializeURLOrigin = notImplemented(
+export const parseURL = /*@__PURE__*/ notImplemented("whatwg-url.parseURL");
+export const basicURLParse = /*@__PURE__*/ notImplemented(
+  "whatwg-url.basicURLParse",
+);
+export const serializeURL = /*@__PURE__*/ notImplemented(
+  "whatwg-url.serializeURL",
+);
+export const serializeHost = /*@__PURE__*/ notImplemented(
+  "whatwg-url.serializeHost",
+);
+export const serializeInteger = /*@__PURE__*/ notImplemented(
+  "whatwg-url.serializeInteger",
+);
+export const serializeURLOrigin = /*@__PURE__*/ notImplemented(
   "whatwg-url.serializeURLOrigin",
 );
-export const setTheUsername = notImplemented("whatwg-url.setTheUsername");
-export const setThePassword = notImplemented("whatwg-url.setThePassword");
-export const cannotHaveAUsernamePasswordPort = notImplemented(
+export const setTheUsername = /*@__PURE__*/ notImplemented(
+  "whatwg-url.setTheUsername",
+);
+export const setThePassword = /*@__PURE__*/ notImplemented(
+  "whatwg-url.setThePassword",
+);
+export const cannotHaveAUsernamePasswordPort = /*@__PURE__*/ notImplemented(
   "whatwg-url.cannotHaveAUsernamePasswordPort",
 );
-export const percentDecodeBytes = notImplemented(
+export const percentDecodeBytes = /*@__PURE__*/ notImplemented(
   "whatwg-url.percentDecodeBytes",
 );
-export const percentDecodeString = notImplemented(
+export const percentDecodeString = /*@__PURE__*/ notImplemented(
   "whatwg-url.percentDecodeString",
 );


### PR DESCRIPTION
Add `/*@__PURE__*/` annotations to mark named exports as side-effect free for rollup/rolldown/esbuild