### PR TITLE
refactor: use `satisfies T` when possible

### DIFF
--- a/src/runtime/node/buffer.ts
+++ b/src/runtime/node/buffer.ts
@@ -37,7 +37,7 @@ export const constants = {
   MAX_STRING_LENGTH: kStringMaxLength,
 };
 
-export default <typeof buffer>{
+export default {
   Buffer,
   SlowBuffer: SlowBuffer as any as typeof buffer.SlowBuffer,
   kMaxLength,
@@ -52,4 +52,4 @@ export default <typeof buffer>{
   isUtf8,
   isAscii,
   File,
-};
+} satisfies typeof buffer;

--- a/src/runtime/node/child_process.ts
+++ b/src/runtime/node/child_process.ts
@@ -34,4 +34,4 @@ export default {
   fork,
   spawn,
   spawnSync,
-} as typeof child_process;
+} as /* TODO: use satisfies */ typeof child_process;

--- a/src/runtime/node/child_process.ts
+++ b/src/runtime/node/child_process.ts
@@ -24,7 +24,7 @@ export const spawn: typeof child_process.spawn = /*@__PURE__*/ notImplemented(
 export const spawnSync: typeof child_process.spawnSync =
   /*@__PURE__*/ notImplemented("child_process.spawnSync");
 
-export default <typeof child_process>{
+export default {
   ChildProcess,
   _forkChild,
   exec,
@@ -34,4 +34,4 @@ export default <typeof child_process>{
   fork,
   spawn,
   spawnSync,
-};
+} as typeof child_process;

--- a/src/runtime/node/constants.ts
+++ b/src/runtime/node/constants.ts
@@ -9,8 +9,8 @@ export * from "./internal/constants/os.ts";
 export * from "./internal/constants/fs.ts";
 export * from "./internal/constants/crypto.ts";
 
-export default <typeof constants>{
+export default {
   ...crypto,
   ...fs,
   ...os,
-};
+} satisfies typeof constants;

--- a/src/runtime/node/dgram.ts
+++ b/src/runtime/node/dgram.ts
@@ -10,8 +10,8 @@ export const createSocket: typeof dgram.createSocket = function () {
   return new Socket();
 };
 
-export default <typeof dgram>{
+export default {
   Socket,
   _createSocketHandle,
   createSocket,
-};
+} as typeof dgram;

--- a/src/runtime/node/dgram.ts
+++ b/src/runtime/node/dgram.ts
@@ -14,4 +14,4 @@ export default {
   Socket,
   _createSocketHandle,
   createSocket,
-} as typeof dgram;
+} as /* TODO: use satisfies */ typeof dgram;

--- a/src/runtime/node/diagnostics_channel.ts
+++ b/src/runtime/node/diagnostics_channel.ts
@@ -47,11 +47,11 @@ export const tracingChannel: typeof diagnostics_channel.tracingChannel =
 
 // TracingChannel is incorrectly exposed on the `diagnostics_channel` type. In addition, its type
 // takes a constructor with no arguments, whereas the node implementation takes a name (matching `tracingChannel`)
-export default <Omit<typeof diagnostics_channel, "TracingChannel">>{
+export default {
   Channel,
   channel,
   hasSubscribers,
   subscribe,
   tracingChannel,
   unsubscribe,
-};
+} satisfies Omit<typeof diagnostics_channel, "TracingChannel">;

--- a/src/runtime/node/dns.ts
+++ b/src/runtime/node/dns.ts
@@ -49,7 +49,7 @@ export const reverse: typeof dns.reverse =
 export const setDefaultResultOrder: typeof dns.setDefaultResultOrder = noop;
 export const setServers: typeof dns.setServers = noop;
 
-export default <typeof dns>{
+export default {
   ...constants,
   Resolver,
   getDefaultResultOrder,
@@ -73,4 +73,4 @@ export default <typeof dns>{
   reverse,
   setDefaultResultOrder,
   setServers,
-};
+} satisfies typeof dns;

--- a/src/runtime/node/dns/promises.ts
+++ b/src/runtime/node/dns/promises.ts
@@ -46,7 +46,7 @@ export const reverse: typeof dns.reverse =
 export const setDefaultResultOrder: typeof dns.setDefaultResultOrder = noop;
 export const setServers: typeof dns.setServers = noop;
 
-export default <typeof dns>{
+export default {
   ...constants,
   Resolver,
   getDefaultResultOrder,
@@ -69,4 +69,4 @@ export default <typeof dns>{
   reverse,
   setDefaultResultOrder,
   setServers,
-};
+} satisfies typeof dns;

--- a/src/runtime/node/domain.ts
+++ b/src/runtime/node/domain.ts
@@ -11,10 +11,10 @@ const _domain = create();
 export const active = () => _domain;
 export const _stack = [];
 
-export default <typeof domain>{
+export default {
   Domain,
   _stack,
   active,
   create,
   createDomain,
-};
+} as typeof domain;

--- a/src/runtime/node/domain.ts
+++ b/src/runtime/node/domain.ts
@@ -17,4 +17,4 @@ export default {
   active,
   create,
   createDomain,
-} as typeof domain;
+} as /* TODO: use satisfies */ typeof domain;

--- a/src/runtime/node/fs.ts
+++ b/src/runtime/node/fs.ts
@@ -13,9 +13,9 @@ export * from "./internal/fs/fs.ts";
 
 export const promises = _promises;
 
-export default <typeof nodeFS>{
+export default {
   ..._classes,
   ..._constants,
   ..._fs,
   promises,
-};
+} satisfies typeof nodeFS;

--- a/src/runtime/node/fs/promises.ts
+++ b/src/runtime/node/fs/promises.ts
@@ -4,6 +4,6 @@ import * as _promises from "../internal/fs/promises.ts";
 
 export * from "../internal/fs/promises.ts";
 
-export default <typeof fsp>{
+export default {
   ..._promises,
-};
+} satisfies typeof fsp;

--- a/src/runtime/node/http.ts
+++ b/src/runtime/node/http.ts
@@ -76,4 +76,4 @@ export default {
   validateHeaderValue,
   setMaxIdleHTTPParsers,
   _connectionListener,
-} as typeof http;
+} as /* TODO: use satisfies */ typeof http;

--- a/src/runtime/node/http.ts
+++ b/src/runtime/node/http.ts
@@ -57,7 +57,7 @@ export const MessageEvent =
   globalThis.MessageEvent ||
   /*@__PURE__*/ notImplementedClass<MessageEvent>("MessageEvent");
 
-export default <typeof http>{
+export default {
   ...consts,
   IncomingMessage: IncomingMessage as any as typeof http.IncomingMessage,
   ServerResponse: ServerResponse as any as typeof http.ServerResponse,
@@ -76,4 +76,4 @@ export default <typeof http>{
   validateHeaderValue,
   setMaxIdleHTTPParsers,
   _connectionListener,
-};
+} as typeof http;

--- a/src/runtime/node/http2.ts
+++ b/src/runtime/node/http2.ts
@@ -46,7 +46,7 @@ export const sensitiveHeaders: typeof http2.sensitiveHeaders = Symbol(
   "nodejs.http2.sensitiveHeaders",
 );
 
-export default <typeof http2>{
+export default {
   constants,
   createSecureServer,
   createServer,
@@ -58,4 +58,4 @@ export default <typeof http2>{
   getUnpackedSettings,
   performServerHandshake,
   sensitiveHeaders,
-};
+} satisfies typeof http2;

--- a/src/runtime/node/https.ts
+++ b/src/runtime/node/https.ts
@@ -20,11 +20,11 @@ export const createServer =
 export const request =
   /*@__PURE__*/ notImplemented<typeof nodeHttps.request>("https.request");
 
-export default <typeof nodeHttps>{
+export default {
   Server,
   Agent,
   globalAgent,
   get,
   createServer,
   request,
-};
+} satisfies typeof nodeHttps;

--- a/src/runtime/node/inspector.ts
+++ b/src/runtime/node/inspector.ts
@@ -25,7 +25,7 @@ export const Session: typeof inspector.Session =
 
 export const Network = mock.__createMock__("inspector.Network");
 
-export default <typeof inspector>{
+export default {
   Session,
   close,
   console,
@@ -33,4 +33,4 @@ export default <typeof inspector>{
   url,
   waitForDebugger,
   Network,
-};
+} satisfies typeof inspector;

--- a/src/runtime/node/internal/fs/promises.ts
+++ b/src/runtime/node/internal/fs/promises.ts
@@ -68,4 +68,4 @@ export const statfs = /*@__PURE__*/ notImplemented<typeof fsp.statfs>(
 ) as typeof fsp.statfs;
 export const glob = /*@__PURE__*/ notImplemented<typeof fsp.glob>("fs.glob");
 
-export default <typeof fsp>{};
+export default {} as typeof fsp;

--- a/src/runtime/node/os.ts
+++ b/src/runtime/node/os.ts
@@ -98,7 +98,7 @@ export const userInfo: typeof os.userInfo = (opts) => {
 
 export const EOL: typeof os.EOL = "\n";
 
-export default <typeof os>{
+export default {
   arch,
   availableParallelism,
   constants,
@@ -122,4 +122,4 @@ export default <typeof os>{
   uptime,
   userInfo,
   version,
-};
+} satisfies typeof os;

--- a/src/runtime/node/readline.ts
+++ b/src/runtime/node/readline.ts
@@ -25,4 +25,4 @@ export default {
   emitKeypressEvents,
   moveCursor,
   promises,
-} as typeof readline;
+} as /* TODO: use satisfies */ typeof readline;

--- a/src/runtime/node/readline.ts
+++ b/src/runtime/node/readline.ts
@@ -15,7 +15,7 @@ export const cursorTo: typeof readline.cursorTo = () => false;
 export const emitKeypressEvents: typeof readline.emitKeypressEvents = noop;
 export const moveCursor: typeof readline.moveCursor = () => false;
 
-export default <typeof readline>{
+export default {
   Interface,
   Readline: Interface,
   clearLine,
@@ -25,4 +25,4 @@ export default <typeof readline>{
   emitKeypressEvents,
   moveCursor,
   promises,
-};
+} as typeof readline;

--- a/src/runtime/node/readline/promises.ts
+++ b/src/runtime/node/readline/promises.ts
@@ -8,8 +8,8 @@ export { Readline } from "../internal/readline/promises/readline.ts";
 export const createInterface: typeof readline.createInterface = () =>
   new Interface();
 
-export default <typeof readline>{
+export default {
   Interface,
   Readline,
   createInterface,
-};
+} as typeof readline;

--- a/src/runtime/node/readline/promises.ts
+++ b/src/runtime/node/readline/promises.ts
@@ -12,4 +12,4 @@ export default {
   Interface,
   Readline,
   createInterface,
-} as typeof readline;
+} as /* TODO: use satisfies */ typeof readline;

--- a/src/runtime/node/stream.ts
+++ b/src/runtime/node/stream.ts
@@ -50,7 +50,7 @@ export const _uint8ArrayToBuffer = /*@__PURE__*/ notImplemented(
   "stream._uint8ArrayToBuffer",
 );
 
-export default <typeof stream & StreamInternal>{
+export default {
   Readable: Readable as unknown as typeof stream.Readable,
   Writable: Writable as unknown as typeof stream.Writable,
   Duplex: Duplex as unknown as typeof stream.Duplex,
@@ -68,4 +68,4 @@ export default <typeof stream & StreamInternal>{
   isErrored,
   destroy,
   _isUint8Array,
-};
+} as typeof stream & StreamInternal;

--- a/src/runtime/node/stream.ts
+++ b/src/runtime/node/stream.ts
@@ -68,4 +68,4 @@ export default {
   isErrored,
   destroy,
   _isUint8Array,
-} as typeof stream & StreamInternal;
+} as /* TODO: use satisfies */ typeof stream & StreamInternal;

--- a/src/runtime/node/stream/consumers.ts
+++ b/src/runtime/node/stream/consumers.ts
@@ -9,10 +9,10 @@ export const buffer = /*@__PURE__*/ notImplemented("stream.consumers.buffer");
 export const text = /*@__PURE__*/ notImplemented("stream.consumers.text");
 export const json = /*@__PURE__*/ notImplemented("stream.consumers.json");
 
-export default <typeof streamConsumers>{
+export default {
   arrayBuffer,
   blob,
   buffer,
   text,
   json,
-};
+} satisfies typeof streamConsumers;

--- a/src/runtime/node/stream/promises.ts
+++ b/src/runtime/node/stream/promises.ts
@@ -8,7 +8,7 @@ export const pipeline = /*@__PURE__*/ notImplemented(
   "stream.promises.pipeline",
 );
 
-export default <typeof streamPromises>{
+export default {
   finished,
   pipeline,
-};
+} satisfies typeof streamPromises;

--- a/src/runtime/node/stream/web.ts
+++ b/src/runtime/node/stream/web.ts
@@ -75,4 +75,4 @@ export default {
   TextDecoderStream,
   DecompressionStream,
   CompressionStream,
-} as typeof streamWeb;
+} as /* TODO: use satisfies */ typeof streamWeb;

--- a/src/runtime/node/stream/web.ts
+++ b/src/runtime/node/stream/web.ts
@@ -57,7 +57,7 @@ export const CompressionStream =
   /*@__PURE__*/ notImplemented("stream.web.CompressionStream");
 
 // @ts-ignore
-export default <typeof streamWeb>{
+export default {
   ReadableStream,
   ReadableStreamDefaultReader,
   ReadableStreamBYOBReader,
@@ -75,4 +75,4 @@ export default <typeof streamWeb>{
   TextDecoderStream,
   DecompressionStream,
   CompressionStream,
-};
+} as typeof streamWeb;

--- a/src/runtime/node/string_decoder.ts
+++ b/src/runtime/node/string_decoder.ts
@@ -6,6 +6,6 @@ export const StringDecoder: typeof stringDecoder.StringDecoder =
   (globalThis as any).StringDecoder ||
   /*@__PURE__*/ notImplementedClass("string_decoder.StringDecoder");
 
-export default <typeof stringDecoder>{
+export default {
   StringDecoder,
-};
+} satisfies typeof stringDecoder;

--- a/src/runtime/node/tls.ts
+++ b/src/runtime/node/tls.ts
@@ -44,4 +44,4 @@ export default {
   createServer,
   getCiphers,
   rootCertificates,
-} as typeof tls;
+} as /* TODO: use satisfies */ typeof tls;

--- a/src/runtime/node/tls.ts
+++ b/src/runtime/node/tls.ts
@@ -31,7 +31,7 @@ export const getCiphers: typeof tls.getCiphers =
 
 export const rootCertificates: typeof tls.rootCertificates = [];
 
-export default <typeof tls>{
+export default {
   ...constants,
   SecureContext,
   Server,
@@ -44,4 +44,4 @@ export default <typeof tls>{
   createServer,
   getCiphers,
   rootCertificates,
-};
+} as typeof tls;

--- a/src/runtime/node/trace_events.ts
+++ b/src/runtime/node/trace_events.ts
@@ -7,7 +7,7 @@ export const createTracing: typeof trace_events.createTracing = function () {
 export const getEnabledCategories: typeof trace_events.getEnabledCategories =
   () => "";
 
-export default <typeof trace_events>{
+export default {
   createTracing,
   getEnabledCategories,
-};
+} satisfies typeof trace_events;

--- a/src/runtime/node/tty.ts
+++ b/src/runtime/node/tty.ts
@@ -9,8 +9,8 @@ export const isatty: typeof tty.isatty = function () {
   return false;
 };
 
-export default <typeof tty>{
+export default {
   ReadStream,
   WriteStream,
   isatty,
-};
+} satisfies typeof tty;

--- a/src/runtime/node/util.ts
+++ b/src/runtime/node/util.ts
@@ -73,7 +73,7 @@ export const getSystemErrorMessage = /*@__PURE__*/ notImplemented<
   typeof util.getSystemErrorMessage
 >("util.getSystemErrorMessage");
 
-export default <typeof util>{
+export default {
   _errnoException,
   _exceptionWithHostPort,
   _extend,
@@ -100,4 +100,4 @@ export default <typeof util>{
   ...mime,
   ...logUtils,
   ...legacyTypes,
-};
+} satisfies typeof util;

--- a/src/runtime/node/util.ts
+++ b/src/runtime/node/util.ts
@@ -100,4 +100,4 @@ export default {
   ...mime,
   ...logUtils,
   ...legacyTypes,
-} satisfies typeof util;
+} as typeof util;

--- a/src/runtime/node/util.ts
+++ b/src/runtime/node/util.ts
@@ -100,4 +100,4 @@ export default {
   ...mime,
   ...logUtils,
   ...legacyTypes,
-} as typeof util;
+} as /* TODO: use satisfies */ typeof util;

--- a/src/runtime/node/v8.ts
+++ b/src/runtime/node/v8.ts
@@ -117,7 +117,7 @@ export function queryObjects(
   return [];
 }
 
-export default <typeof v8>{
+export default {
   DefaultDeserializer,
   Deserializer,
   GCProfiler,
@@ -138,4 +138,4 @@ export default <typeof v8>{
   takeCoverage,
   writeHeapSnapshot,
   queryObjects,
-};
+} satisfies typeof v8;

--- a/src/runtime/node/vm.ts
+++ b/src/runtime/node/vm.ts
@@ -42,9 +42,7 @@ export const runInNewContext: typeof vm.runInNewContext =
 export const runInThisContext: typeof vm.runInThisContext =
   /*@__PURE__*/ notImplemented("vm.runInThisContext");
 
-export default <
-  Omit<typeof vm, "Module" | "SourceTextModule" | "SyntheticModule">
->{
+export default {
   Script,
   compileFunction,
   constants,
@@ -55,4 +53,4 @@ export default <
   runInContext,
   runInNewContext,
   runInThisContext,
-};
+} as Omit<typeof vm, "Module" | "SourceTextModule" | "SyntheticModule">;

--- a/src/runtime/node/vm.ts
+++ b/src/runtime/node/vm.ts
@@ -53,4 +53,7 @@ export default {
   runInContext,
   runInNewContext,
   runInThisContext,
-} as Omit<typeof vm, "Module" | "SourceTextModule" | "SyntheticModule">;
+} as /* TODO: use satisfies */ Omit<
+  typeof vm,
+  "Module" | "SourceTextModule" | "SyntheticModule"
+>;

--- a/src/runtime/node/worker_threads.ts
+++ b/src/runtime/node/worker_threads.ts
@@ -57,7 +57,7 @@ export const postMessageToThread = /*@__PURE__*/ notImplemented(
   "worker_threads.postMessageToThread",
 );
 
-export default <typeof worker_threads>{
+export default {
   BroadcastChannel,
   MessageChannel,
   MessagePort,
@@ -76,4 +76,4 @@ export default <typeof worker_threads>{
   postMessageToThread,
   threadId,
   workerData,
-};
+} as typeof worker_threads;

--- a/src/runtime/node/worker_threads.ts
+++ b/src/runtime/node/worker_threads.ts
@@ -76,4 +76,4 @@ export default {
   postMessageToThread,
   threadId,
   workerData,
-} as typeof worker_threads;
+} as /* TODO: use satisfies */ typeof worker_threads;


### PR DESCRIPTION
Use `{} satisfies T` when possible for better emitted types and safety and also `{} as T` instead of `<T>{}` for node stript type compatibility (marked as TODO to migrate to satisfies)