### PR TITLE
fix: full coverage for (esm) node exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ const envConfig = env(nodeless, {});
 
 <!-- automd:file src="./coverage/unenv.md" -->
 
-- 🚧 [node:assert](https://nodejs.org/api/assert.html) <!-- missing partialDeepStrictEqual exports -->
-- 🚧 [node:assert/strict](https://nodejs.org/api/assert.html) <!-- missing partialDeepStrictEqual exports -->
+- ✅ [node:assert](https://nodejs.org/api/assert.html)
+- ✅ [node:assert/strict](https://nodejs.org/api/assert.html)
 - ✅ [node:async_hooks](https://nodejs.org/api/async_hooks.html)
 - ✅ [node:buffer](https://nodejs.org/api/buffer.html)
 - ✅ [node:child_process](https://nodejs.org/api/child_process.html)
@@ -128,8 +128,8 @@ const envConfig = env(nodeless, {});
 - ✅ [node:querystring](https://nodejs.org/api/querystring.html)
 - ✅ [node:readline](https://nodejs.org/api/readline.html)
 - ✅ [node:readline/promises](https://nodejs.org/api/readline.html)
-- 🚧 [node:repl](https://nodejs.org/api/repl.html) <!-- missing builtinModules exports -->
-- 🚧 [node:stream](https://nodejs.org/api/stream.html) <!-- missing _isArrayBufferView, duplexPair, getDefaultHighWaterMark, isDestroyed, isWritable, promises, setDefaultHighWaterMark exports -->
+- ✅ [node:repl](https://nodejs.org/api/repl.html)
+- ✅ [node:stream](https://nodejs.org/api/stream.html)
 - ✅ [node:stream/consumers](https://nodejs.org/api/stream.html)
 - ✅ [node:stream/promises](https://nodejs.org/api/stream.html)
 - ✅ [node:stream/web](https://nodejs.org/api/stream.html)
@@ -147,7 +147,7 @@ const envConfig = env(nodeless, {});
 - ✅ [node:vm](https://nodejs.org/api/vm.html)
 - ✅ [node:wasi](https://nodejs.org/api/wasi.html)
 - ✅ [node:worker_threads](https://nodejs.org/api/worker_threads.html)
-- 🚧 [node:zlib](https://nodejs.org/api/zlib.html) <!-- missing crc32 exports -->
+- ✅ [node:zlib](https://nodejs.org/api/zlib.html)
 
 <!-- /automd -->
 

--- a/src/runtime/node/assert.ts
+++ b/src/runtime/node/assert.ts
@@ -22,10 +22,10 @@
 // Based on Node.js' assert module
 // https://github.com/nodejs/node/blob/0db95d371274104a5acf09214bf8325c45bfb64a/lib/assert.js
 
-import type nodeAssert from "node:assert";
+import nodeAssert from "node:assert";
 
 import { isEqual as _ohashIsEqual } from "ohash";
-import { notImplementedClass } from "../_internal/utils.ts";
+import { notImplemented, notImplementedClass } from "../_internal/utils.ts";
 
 // TODO: Implement Error classes
 const ERR_AMBIGUOUS_ARGUMENT = Error;
@@ -539,10 +539,8 @@ class Comparison {
           obj[key] instanceof RegExp &&
           obj[key].exec(actual[key]) !== null
         ) {
-          // @ts-expect-error
           this[key] = actual[key];
         } else {
-          // @ts-expect-error
           this[key] = obj[key];
         }
       }
@@ -635,7 +633,6 @@ function expectedException(
       }
       for (const key of keys) {
         if (
-          // @ts-expect-error
           typeof actual[key] === "string" &&
           // @ts-expect-error
           expected[key] instanceof RegExp &&
@@ -931,6 +928,10 @@ const assert = Object.assign(ok, {}) as typeof nodeAssert;
 export const CallTracker = /*@__PURE__*/ notImplementedClass(
   "asset.CallTracker",
 ) as typeof nodeAssert.CallTracker;
+
+export const partialDeepStrictEqual = /* @__PURE__ */ notImplemented(
+  "assert.partialDeepStrictEqual",
+);
 
 assert.fail = fail;
 assert.ok = ok;

--- a/src/runtime/node/assert.ts
+++ b/src/runtime/node/assert.ts
@@ -539,8 +539,10 @@ class Comparison {
           obj[key] instanceof RegExp &&
           obj[key].exec(actual[key]) !== null
         ) {
+          // @ts-expect-error
           this[key] = actual[key];
         } else {
+          // @ts-expect-error
           this[key] = obj[key];
         }
       }
@@ -633,6 +635,7 @@ function expectedException(
       }
       for (const key of keys) {
         if (
+          // @ts-expect-error
           typeof actual[key] === "string" &&
           // @ts-expect-error
           expected[key] instanceof RegExp &&

--- a/src/runtime/node/assert/strict.ts
+++ b/src/runtime/node/assert/strict.ts
@@ -21,6 +21,7 @@ import {
   notStrictEqual as notEqual,
   deepStrictEqual,
   deepStrictEqual as deepEqual,
+  partialDeepStrictEqual,
 } from "../assert.ts";
 
 export {
@@ -44,6 +45,7 @@ export {
   notStrictEqual as notEqual,
   deepStrictEqual,
   deepStrictEqual as deepEqual,
+  partialDeepStrictEqual,
 } from "../assert.ts";
 
 export default Object.assign(ok, {
@@ -67,4 +69,5 @@ export default Object.assign(ok, {
   notEqual,
   deepStrictEqual,
   deepEqual,
+  partialDeepStrictEqual,
 }) as typeof nodeAssert.strict; // TODO: utils are strict by default so should be typed as strict!

--- a/src/runtime/node/repl.ts
+++ b/src/runtime/node/repl.ts
@@ -1,4 +1,5 @@
 import type nodeRepl from "node:repl";
+import { builtinModules as _builtinModules } from "node:module";
 import { notImplemented, notImplementedClass } from "../_internal/utils.ts";
 
 export const writer =
@@ -23,11 +24,16 @@ export const REPL_MODE_SLOPPY: unique symbol =
 export const REPL_MODE_STRICT: unique symbol =
   /*@__PURE__*/ Symbol("repl-strict");
 
+export const builtinModules = /*@__PURE__*/ _builtinModules.filter(
+  (m) => m[0] !== "_",
+);
+
 export default {
   writer,
   start,
   Recoverable,
   REPLServer,
+  builtinModules,
   // @ts-expect-error
   REPL_MODE_SLOPPY,
   // @ts-expect-error

--- a/src/runtime/node/stream.ts
+++ b/src/runtime/node/stream.ts
@@ -9,6 +9,8 @@ import { Transform } from "./internal/stream/transform.ts";
 
 import promises from "./stream/promises.ts";
 
+export { default as promises } from "./stream/promises.ts";
+
 export { Readable } from "./internal/stream/readable.ts";
 export { Writable } from "./internal/stream/writable.ts";
 export { Duplex } from "./internal/stream/duplex.ts";
@@ -28,16 +30,6 @@ export const addAbortSignal = /*@__PURE__*/ notImplemented<
   typeof stream.addAbortSignal
 >("stream.addAbortSignal");
 
-// Internal
-interface StreamInternal {
-  isDisturbed: any;
-  isReadable: any;
-  compose: any;
-  isErrored: any;
-  destroy: any;
-  _isUint8Array: any;
-  _uint8ArrayToBuffer: any;
-}
 export const isDisturbed = /*@__PURE__*/ notImplemented("stream.isDisturbed");
 export const isReadable = /*@__PURE__*/ notImplemented("stream.isReadable");
 export const compose = /*@__PURE__*/ notImplemented("stream.compose");
@@ -48,6 +40,24 @@ export const _isUint8Array = /*@__PURE__*/ notImplemented(
 );
 export const _uint8ArrayToBuffer = /*@__PURE__*/ notImplemented(
   "stream._uint8ArrayToBuffer",
+);
+
+export const _isArrayBufferView = /*@__PURE__*/ notImplemented(
+  "stream._isArrayBufferView",
+);
+
+export const duplexPair = /*@__PURE__*/ notImplemented("stream.duplexPair");
+
+export const getDefaultHighWaterMark = /*@__PURE__*/ notImplemented(
+  "stream.getDefaultHighWaterMark",
+);
+
+export const isDestroyed = /*@__PURE__*/ notImplemented("stream.isDestroyed");
+
+export const isWritable = /*@__PURE__*/ notImplemented("stream.isWritable");
+
+export const setDefaultHighWaterMark = /*@__PURE__*/ notImplemented(
+  "stream.setDefaultHighWaterMark",
 );
 
 export default {
@@ -68,4 +78,24 @@ export default {
   isErrored,
   destroy,
   _isUint8Array,
-} as /* TODO: use satisfies */ typeof stream & StreamInternal;
+  _isArrayBufferView,
+  duplexPair,
+  getDefaultHighWaterMark,
+  isDestroyed,
+  isWritable,
+  setDefaultHighWaterMark,
+} as /* TODO: use satisfies */ typeof stream & {
+  isDisturbed: any;
+  isReadable: any;
+  compose: any;
+  isErrored: any;
+  destroy: any;
+  _isUint8Array: any;
+  _uint8ArrayToBuffer: any;
+  _isArrayBufferView: any;
+  duplexPair: any;
+  getDefaultHighWaterMark: any;
+  isDestroyed: any;
+  isWritable: any;
+  setDefaultHighWaterMark: any;
+};

--- a/src/runtime/node/zlib.ts
+++ b/src/runtime/node/zlib.ts
@@ -7,6 +7,7 @@ import * as _brotli from "./internal/zlib/formats/brotli.ts";
 import * as _deflate from "./internal/zlib/formats/deflate.ts";
 import * as _gzip from "./internal/zlib/formats/gzip.ts";
 import * as _zip from "./internal/zlib/formats/zip.ts";
+import { notImplemented } from "../_internal/utils.ts";
 
 export { constants } from "./internal/zlib/constants.ts";
 export { codes } from "./internal/zlib/codes.ts";
@@ -15,6 +16,9 @@ export * from "./internal/zlib/formats/brotli.ts";
 export * from "./internal/zlib/formats/deflate.ts";
 export * from "./internal/zlib/formats/gzip.ts";
 export * from "./internal/zlib/formats/zip.ts";
+
+export const crc32 =
+  /*@__PURE__*/ notImplemented<typeof zlib.crc32>("zlib.crc32");
 
 // Deprecated constants
 const Z_BINARY: typeof zlib.Z_BINARY = 0;


### PR DESCRIPTION
Full coverage of Node.js (v22.13.0) exports

<img width="315" alt="image" src="https://github.com/user-attachments/assets/4512f042-78ac-465c-9b71-330be16804ed" />
