### PR TITLE
refactor: import node types as nodeSomeModule

### DIFF
--- a/src/runtime/node/assert.ts
+++ b/src/runtime/node/assert.ts
@@ -22,7 +22,7 @@
 // Based on Node.js' assert module
 // https://github.com/nodejs/node/blob/0db95d371274104a5acf09214bf8325c45bfb64a/lib/assert.js
 
-import nodeAssert from "node:assert";
+import type nodeAssert from "node:assert";
 
 import { isEqual as _ohashIsEqual } from "ohash";
 import { notImplemented, notImplementedClass } from "../_internal/utils.ts";

--- a/src/runtime/node/async_hooks.ts
+++ b/src/runtime/node/async_hooks.ts
@@ -1,5 +1,5 @@
 // https://nodejs.org/api/events.html
-import type asyncHooks from "node:async_hooks";
+import type nodeAsyncHooks from "node:async_hooks";
 
 import { AsyncLocalStorage } from "./internal/async_hooks/async-local-storage.ts";
 import { AsyncResource } from "./internal/async_hooks/async-resource.ts";
@@ -15,4 +15,4 @@ export default {
   AsyncLocalStorage,
   AsyncResource,
   ...asyncHook,
-} satisfies typeof asyncHooks;
+} satisfies typeof nodeAsyncHooks;

--- a/src/runtime/node/buffer.ts
+++ b/src/runtime/node/buffer.ts
@@ -1,5 +1,5 @@
 // https://nodejs.org/api/buffer.html
-import type buffer from "node:buffer";
+import type nodeBuffer from "node:buffer";
 import { notImplemented } from "../_internal/utils.ts";
 import {
   Buffer as _Buffer,
@@ -20,7 +20,7 @@ export const Buffer = globalThis.Buffer || _Buffer;
 export { File } from "./internal/buffer/file.ts";
 
 // @ts-expect-eerror https://github.com/unjs/unenv/issues/64
-export const Blob = globalThis.Blob as unknown as typeof buffer.Blob;
+export const Blob = globalThis.Blob as unknown as typeof nodeBuffer.Blob;
 export const resolveObjectURL = /*@__PURE__*/ notImplemented(
   "buffer.resolveObjectURL",
 );
@@ -39,7 +39,7 @@ export const constants = {
 
 export default {
   Buffer,
-  SlowBuffer: SlowBuffer as any as typeof buffer.SlowBuffer,
+  SlowBuffer: SlowBuffer as any as typeof nodeBuffer.SlowBuffer,
   kMaxLength,
   INSPECT_MAX_BYTES,
   Blob,
@@ -52,4 +52,4 @@ export default {
   isUtf8,
   isAscii,
   File,
-} satisfies typeof buffer;
+} satisfies typeof nodeBuffer;

--- a/src/runtime/node/child_process.ts
+++ b/src/runtime/node/child_process.ts
@@ -1,27 +1,26 @@
 import { notImplemented, notImplementedClass } from "../_internal/utils.ts";
-import type child_process from "node:child_process";
+import type nodeChildProcess from "node:child_process";
 
-export const ChildProcess: typeof child_process.ChildProcess =
+export const ChildProcess: typeof nodeChildProcess.ChildProcess =
   /*@__PURE__*/ notImplementedClass("child_process.ChildProcess");
 
 export const _forkChild = /*@__PURE__*/ notImplemented(
   "child_process.ChildProcess",
 );
 
-export const exec: typeof child_process.exec =
+export const exec: typeof nodeChildProcess.exec =
   /*@__PURE__*/ notImplemented("child_process.exec");
-export const execFile: typeof child_process.execFile =
+export const execFile: typeof nodeChildProcess.execFile =
   /*@__PURE__*/ notImplemented("child_process.execFile");
-export const execFileSync: typeof child_process.execFileSync =
+export const execFileSync: typeof nodeChildProcess.execFileSync =
   /*@__PURE__*/ notImplemented("child_process.execFileSync");
-export const execSync: typeof child_process.execSync =
+export const execSync: typeof nodeChildProcess.execSync =
   /*@__PURE__*/ notImplemented("child_process.execSyn");
-export const fork: typeof child_process.fork =
+export const fork: typeof nodeChildProcess.fork =
   /*@__PURE__*/ notImplemented("child_process.fork");
-export const spawn: typeof child_process.spawn = /*@__PURE__*/ notImplemented(
-  "child_process.spawn",
-);
-export const spawnSync: typeof child_process.spawnSync =
+export const spawn: typeof nodeChildProcess.spawn =
+  /*@__PURE__*/ notImplemented("child_process.spawn");
+export const spawnSync: typeof nodeChildProcess.spawnSync =
   /*@__PURE__*/ notImplemented("child_process.spawnSync");
 
 export default {
@@ -34,4 +33,4 @@ export default {
   fork,
   spawn,
   spawnSync,
-} as /* TODO: use satisfies */ typeof child_process;
+} as /* TODO: use satisfies */ typeof nodeChildProcess;

--- a/src/runtime/node/console.ts
+++ b/src/runtime/node/console.ts
@@ -1,4 +1,4 @@
-import type console from "node:console";
+import type nodeConsole from "node:console";
 import { Writable } from "node:stream";
 import mock from "../mock/proxy.ts";
 import noop from "../mock/noop.ts";
@@ -11,42 +11,43 @@ export const _ignoreErrors: boolean = true;
 export const _stderr: Writable = new Writable();
 export const _stdout: Writable = new Writable();
 
-export const log: typeof console.log = _console?.log ?? noop;
-export const info: typeof console.info = _console?.info ?? log;
-export const trace: typeof console.trace = _console?.trace ?? info;
-export const debug: typeof console.debug = _console?.debug ?? log;
-export const table: typeof console.table = _console?.table ?? log;
-export const error: typeof console.error = _console?.error ?? log;
-export const warn: typeof console.warn = _console?.warn ?? error;
+export const log: typeof nodeConsole.log = _console?.log ?? noop;
+export const info: typeof nodeConsole.info = _console?.info ?? log;
+export const trace: typeof nodeConsole.trace = _console?.trace ?? info;
+export const debug: typeof nodeConsole.debug = _console?.debug ?? log;
+export const table: typeof nodeConsole.table = _console?.table ?? log;
+export const error: typeof nodeConsole.error = _console?.error ?? log;
+export const warn: typeof nodeConsole.warn = _console?.warn ?? error;
 
 // https://developer.chrome.com/docs/devtools/console/api#createtask
 export const createTask =
   (_console as any)?.createTask ??
   /*@__PURE__*/ notImplemented("console.createTask");
 
-export const assert: typeof console.assert =
-  /*@__PURE__*/ notImplemented<typeof console.assert>("console.assert");
+export const assert: typeof nodeConsole.assert =
+  /*@__PURE__*/ notImplemented<typeof nodeConsole.assert>("console.assert");
 
 // noop
-export const clear: typeof console.clear = _console?.clear ?? noop;
-export const count: typeof console.count = _console?.count ?? noop;
-export const countReset: typeof console.countReset =
+export const clear: typeof nodeConsole.clear = _console?.clear ?? noop;
+export const count: typeof nodeConsole.count = _console?.count ?? noop;
+export const countReset: typeof nodeConsole.countReset =
   _console?.countReset ?? noop;
-export const dir: typeof console.dir = _console?.dir ?? noop;
-export const dirxml: typeof console.dirxml = _console?.dirxml ?? noop;
-export const group: typeof console.group = _console?.group ?? noop;
-export const groupEnd: typeof console.groupEnd = _console?.groupEnd ?? noop;
-export const groupCollapsed: typeof console.groupCollapsed =
+export const dir: typeof nodeConsole.dir = _console?.dir ?? noop;
+export const dirxml: typeof nodeConsole.dirxml = _console?.dirxml ?? noop;
+export const group: typeof nodeConsole.group = _console?.group ?? noop;
+export const groupEnd: typeof nodeConsole.groupEnd = _console?.groupEnd ?? noop;
+export const groupCollapsed: typeof nodeConsole.groupCollapsed =
   _console?.groupCollapsed ?? noop;
-export const profile: typeof console.profile = _console?.profile ?? noop;
-export const profileEnd: typeof console.profileEnd =
+export const profile: typeof nodeConsole.profile = _console?.profile ?? noop;
+export const profileEnd: typeof nodeConsole.profileEnd =
   _console?.profileEnd ?? noop;
-export const time: typeof console.time = _console?.time ?? noop;
-export const timeEnd: typeof console.timeEnd = _console?.timeEnd ?? noop;
-export const timeLog: typeof console.timeLog = _console?.timeLog ?? noop;
-export const timeStamp: typeof console.timeStamp = _console?.timeStamp ?? noop;
+export const time: typeof nodeConsole.time = _console?.time ?? noop;
+export const timeEnd: typeof nodeConsole.timeEnd = _console?.timeEnd ?? noop;
+export const timeLog: typeof nodeConsole.timeLog = _console?.timeLog ?? noop;
+export const timeStamp: typeof nodeConsole.timeStamp =
+  _console?.timeStamp ?? noop;
 
-export const Console: typeof console.Console =
+export const Console: typeof nodeConsole.Console =
   _console?.Console ?? mock.__createMock__("console.Console");
 
 export { default as _times } from "../mock/proxy.ts";
@@ -88,4 +89,4 @@ export default {
   timeStamp,
   trace,
   warn,
-} satisfies typeof console;
+} satisfies typeof nodeConsole;

--- a/src/runtime/node/constants.ts
+++ b/src/runtime/node/constants.ts
@@ -1,6 +1,6 @@
 // Mostly taken from: https://github.com/nodejs/node/blob/main/typings/internalBinding/constants.d.ts
 
-import type constants from "node:constants";
+import type nodeConstants from "node:constants";
 import * as os from "./internal/constants/os.ts";
 import * as fs from "./internal/constants/fs.ts";
 import * as crypto from "./internal/constants/crypto.ts";
@@ -13,4 +13,4 @@ export default {
   ...crypto,
   ...fs,
   ...os,
-} satisfies typeof constants;
+} satisfies typeof nodeConstants;

--- a/src/runtime/node/dgram.ts
+++ b/src/runtime/node/dgram.ts
@@ -1,12 +1,12 @@
 import noop from "../mock/noop.ts";
-import type dgram from "node:dgram";
+import type nodeDgram from "node:dgram";
 import { Socket } from "./internal/dgram/socket.ts";
 
 export { Socket } from "./internal/dgram/socket.ts";
 
 export const _createSocketHandle = noop;
 
-export const createSocket: typeof dgram.createSocket = function () {
+export const createSocket: typeof nodeDgram.createSocket = function () {
   return new Socket();
 };
 
@@ -14,4 +14,4 @@ export default {
   Socket,
   _createSocketHandle,
   createSocket,
-} as /* TODO: use satisfies */ typeof dgram;
+} as /* TODO: use satisfies */ typeof nodeDgram;

--- a/src/runtime/node/diagnostics_channel.ts
+++ b/src/runtime/node/diagnostics_channel.ts
@@ -1,4 +1,4 @@
-import type diagnostics_channel from "node:diagnostics_channel";
+import type nodeDiagnosticsChannel from "node:diagnostics_channel";
 import {
   Channel,
   getChannels,
@@ -7,7 +7,7 @@ import { TracingChannel } from "./internal/diagnostics_channel/tracing-channel.t
 
 export { Channel } from "./internal/diagnostics_channel/channel.ts";
 
-export const channel: typeof diagnostics_channel.channel = function (name) {
+export const channel: typeof nodeDiagnosticsChannel.channel = function (name) {
   const channels = getChannels();
   if (name in channels) {
     return channels[name];
@@ -15,32 +15,32 @@ export const channel: typeof diagnostics_channel.channel = function (name) {
   return new Channel(name);
 };
 
-export const hasSubscribers: typeof diagnostics_channel.hasSubscribers =
+export const hasSubscribers: typeof nodeDiagnosticsChannel.hasSubscribers =
   function (name) {
     const channels = getChannels();
     const channel = channels[name];
     return channel && channel.hasSubscribers;
   };
 
-export const subscribe: typeof diagnostics_channel.subscribe = function (
+export const subscribe: typeof nodeDiagnosticsChannel.subscribe = function (
   name,
   onMessage,
 ) {
   channel(name).subscribe(onMessage);
 };
 
-export const unsubscribe: typeof diagnostics_channel.unsubscribe = function (
+export const unsubscribe: typeof nodeDiagnosticsChannel.unsubscribe = function (
   name,
   onMessage,
 ) {
   return (channel(name) as Channel<unknown, object>).unsubscribe(onMessage);
 };
 
-export const tracingChannel: typeof diagnostics_channel.tracingChannel =
+export const tracingChannel: typeof nodeDiagnosticsChannel.tracingChannel =
   function <StoreType = unknown, ContextType extends object = object>(
     name:
       | string
-      | diagnostics_channel.TracingChannelCollection<StoreType, ContextType>,
+      | nodeDiagnosticsChannel.TracingChannelCollection<StoreType, ContextType>,
   ) {
     return new TracingChannel<StoreType, ContextType>(name);
   };
@@ -54,4 +54,4 @@ export default {
   subscribe,
   tracingChannel,
   unsubscribe,
-} satisfies Omit<typeof diagnostics_channel, "TracingChannel">;
+} satisfies Omit<typeof nodeDiagnosticsChannel, "TracingChannel">;

--- a/src/runtime/node/dns.ts
+++ b/src/runtime/node/dns.ts
@@ -1,53 +1,53 @@
 import noop from "../mock/noop.ts";
 import mock from "../mock/proxy.ts";
 import { notImplemented, notImplementedAsync } from "../_internal/utils.ts";
-import type dns from "node:dns";
+import type nodeDns from "node:dns";
 import promises from "./dns/promises.ts";
 import * as constants from "./internal/dns/constants.ts";
 
 export * from "./internal/dns/constants.ts";
 export * as promises from "./dns/promises.ts";
 
-export const Resolver: typeof dns.Resolver =
+export const Resolver: typeof nodeDns.Resolver =
   mock.__createMock__("dns.Resolver");
-export const getDefaultResultOrder: typeof dns.getDefaultResultOrder = () =>
+export const getDefaultResultOrder: typeof nodeDns.getDefaultResultOrder = () =>
   "verbatim";
-export const getServers: typeof dns.getServers = () => [];
-export const lookup: typeof dns.lookup =
+export const getServers: typeof nodeDns.getServers = () => [];
+export const lookup: typeof nodeDns.lookup =
   /*@__PURE__*/ notImplementedAsync("dns.lookup");
-export const lookupService: typeof dns.lookupService =
+export const lookupService: typeof nodeDns.lookupService =
   /*@__PURE__*/ notImplementedAsync("dns.lookupService");
-export const resolve: typeof dns.resolve =
+export const resolve: typeof nodeDns.resolve =
   /*@__PURE__*/ notImplementedAsync("dns.resolve");
-export const resolve4: typeof dns.resolve4 =
+export const resolve4: typeof nodeDns.resolve4 =
   /*@__PURE__*/ notImplementedAsync("dns.resolve4");
-export const resolve6: typeof dns.resolve6 =
+export const resolve6: typeof nodeDns.resolve6 =
   /*@__PURE__*/ notImplementedAsync("dns.resolve6");
-export const resolveAny: typeof dns.resolveAny =
+export const resolveAny: typeof nodeDns.resolveAny =
   /*@__PURE__*/ notImplementedAsync("dns.resolveAny");
-export const resolveCaa: typeof dns.resolveCaa =
+export const resolveCaa: typeof nodeDns.resolveCaa =
   /*@__PURE__*/ notImplementedAsync("dns.resolveCaa");
-export const resolveCname: typeof dns.resolveCname =
+export const resolveCname: typeof nodeDns.resolveCname =
   /*@__PURE__*/ notImplementedAsync("dns.resolveCname");
-export const resolveMx: typeof dns.resolveMx =
+export const resolveMx: typeof nodeDns.resolveMx =
   /*@__PURE__*/ notImplementedAsync("dns.resolveMx");
-export const resolveNaptr: typeof dns.resolveNaptr =
+export const resolveNaptr: typeof nodeDns.resolveNaptr =
   /*@__PURE__*/ notImplementedAsync("dns.resolveNaptr");
-export const resolveNs: typeof dns.resolveNs =
+export const resolveNs: typeof nodeDns.resolveNs =
   /*@__PURE__*/ notImplementedAsync("dns.resolveNs");
-export const resolvePtr: typeof dns.resolvePtr =
+export const resolvePtr: typeof nodeDns.resolvePtr =
   /*@__PURE__*/ notImplementedAsync("dns.resolvePtr");
-export const resolveSoa: typeof dns.resolveSoa =
+export const resolveSoa: typeof nodeDns.resolveSoa =
   /*@__PURE__*/ notImplementedAsync("dns.resolveSoa");
-export const resolveSrv: typeof dns.resolveSrv =
+export const resolveSrv: typeof nodeDns.resolveSrv =
   /*@__PURE__*/ notImplementedAsync("dns.resolveSrv");
-export const resolveTxt: typeof dns.resolveTxt =
+export const resolveTxt: typeof nodeDns.resolveTxt =
   /*@__PURE__*/ notImplementedAsync("dns.resolveTxt");
 
-export const reverse: typeof dns.reverse =
+export const reverse: typeof nodeDns.reverse =
   /*@__PURE__*/ notImplemented("dns.reverse");
-export const setDefaultResultOrder: typeof dns.setDefaultResultOrder = noop;
-export const setServers: typeof dns.setServers = noop;
+export const setDefaultResultOrder: typeof nodeDns.setDefaultResultOrder = noop;
+export const setServers: typeof nodeDns.setServers = noop;
 
 export default {
   ...constants,
@@ -73,4 +73,4 @@ export default {
   reverse,
   setDefaultResultOrder,
   setServers,
-} satisfies typeof dns;
+} satisfies typeof nodeDns;

--- a/src/runtime/node/domain.ts
+++ b/src/runtime/node/domain.ts
@@ -1,12 +1,12 @@
-import type domain from "node:domain";
+import type nodeDomain from "node:domain";
 import { Domain } from "./internal/domain/domain.ts";
 
 export { Domain } from "./internal/domain/domain.ts";
 
-export const create: typeof domain.create = function () {
+export const create: typeof nodeDomain.create = function () {
   return new Domain();
 };
-export const createDomain: typeof domain.create = create;
+export const createDomain: typeof nodeDomain.create = create;
 const _domain = create();
 export const active = () => _domain;
 export const _stack = [];
@@ -17,4 +17,4 @@ export default {
   active,
   create,
   createDomain,
-} as /* TODO: use satisfies */ typeof domain;
+} as /* TODO: use satisfies */ typeof nodeDomain;

--- a/src/runtime/node/http.ts
+++ b/src/runtime/node/http.ts
@@ -1,5 +1,5 @@
 // https://nodejs.org/api/http.html
-import type http from "node:http";
+import type nodeHttp from "node:http";
 import { notImplemented, notImplementedClass } from "../_internal/utils.ts";
 import mock from "../mock/proxy.ts";
 import * as consts from "./internal/http/consts.ts";
@@ -11,34 +11,37 @@ export * from "./internal/http/request.ts";
 export * from "./internal/http/response.ts";
 
 export const createServer =
-  /*@__PURE__*/ notImplemented<typeof http.createServer>("http.createServer");
+  /*@__PURE__*/ notImplemented<typeof nodeHttp.createServer>(
+    "http.createServer",
+  );
 export const request =
-  /*@__PURE__*/ notImplemented<typeof http.request>("http.request");
-export const get = /*@__PURE__*/ notImplemented<typeof http.get>("http.get");
+  /*@__PURE__*/ notImplemented<typeof nodeHttp.request>("http.request");
+export const get =
+  /*@__PURE__*/ notImplemented<typeof nodeHttp.get>("http.get");
 
-export const Server: typeof http.Server = mock.__createMock__("http.Server");
+export const Server: typeof nodeHttp.Server =
+  mock.__createMock__("http.Server");
 
-export const OutgoingMessage: typeof http.OutgoingMessage = mock.__createMock__(
-  "http.OutgoingMessage",
-);
+export const OutgoingMessage: typeof nodeHttp.OutgoingMessage =
+  mock.__createMock__("http.OutgoingMessage");
 
-export const ClientRequest: typeof http.ClientRequest =
+export const ClientRequest: typeof nodeHttp.ClientRequest =
   mock.__createMock__("http.ClientRequest");
 
-export const Agent: typeof http.Agent = mock.__createMock__("http.Agent");
+export const Agent: typeof nodeHttp.Agent = mock.__createMock__("http.Agent");
 
-export const globalAgent: typeof http.globalAgent = new Agent();
+export const globalAgent: typeof nodeHttp.globalAgent = new Agent();
 
 export const validateHeaderName = /*@__PURE__*/ notImplemented<
-  typeof http.validateHeaderName
+  typeof nodeHttp.validateHeaderName
 >("http.validateHeaderName");
 
 export const validateHeaderValue = /*@__PURE__*/ notImplemented<
-  typeof http.validateHeaderValue
+  typeof nodeHttp.validateHeaderValue
 >("http.validateHeaderValue");
 
 export const setMaxIdleHTTPParsers = /*@__PURE__*/ notImplemented<
-  typeof http.setMaxIdleHTTPParsers
+  typeof nodeHttp.setMaxIdleHTTPParsers
 >("http.setMaxIdleHTTPParsers");
 
 export const _connectionListener = /*@__PURE__*/ notImplemented(
@@ -59,11 +62,11 @@ export const MessageEvent =
 
 export default {
   ...consts,
-  IncomingMessage: IncomingMessage as any as typeof http.IncomingMessage,
-  ServerResponse: ServerResponse as any as typeof http.ServerResponse,
-  WebSocket: WebSocket as any as typeof http.WebSocket,
-  CloseEvent: CloseEvent as any as typeof http.CloseEvent,
-  MessageEvent: MessageEvent as any as typeof http.MessageEvent,
+  IncomingMessage: IncomingMessage as any as typeof nodeHttp.IncomingMessage,
+  ServerResponse: ServerResponse as any as typeof nodeHttp.ServerResponse,
+  WebSocket: WebSocket as any as typeof nodeHttp.WebSocket,
+  CloseEvent: CloseEvent as any as typeof nodeHttp.CloseEvent,
+  MessageEvent: MessageEvent as any as typeof nodeHttp.MessageEvent,
   createServer,
   request,
   get,
@@ -76,4 +79,4 @@ export default {
   validateHeaderValue,
   setMaxIdleHTTPParsers,
   _connectionListener,
-} as /* TODO: use satisfies */ typeof http;
+} as /* TODO: use satisfies */ typeof nodeHttp;

--- a/src/runtime/node/http2.ts
+++ b/src/runtime/node/http2.ts
@@ -1,48 +1,52 @@
 import mock from "../mock/proxy.ts";
-import type http2 from "node:http2";
+import type nodeHttp2 from "node:http2";
 import { notImplemented } from "../_internal/utils.ts";
 import { constants } from "./internal/http2/constants.ts";
 
 export { constants } from "./internal/http2/constants.ts";
 
 export const createSecureServer = /*@__PURE__*/ notImplemented<
-  typeof http2.createSecureServer
+  typeof nodeHttp2.createSecureServer
 >("http2.createSecureServer");
 export const createServer =
-  /*@__PURE__*/ notImplemented<typeof http2.createServer>("http2.createServer");
-export const connect: typeof http2.connect =
+  /*@__PURE__*/ notImplemented<typeof nodeHttp2.createServer>(
+    "http2.createServer",
+  );
+export const connect: typeof nodeHttp2.connect =
   /*@__PURE__*/ notImplemented("http2.connect");
-export const performServerHandshake: typeof http2.performServerHandshake =
+export const performServerHandshake: typeof nodeHttp2.performServerHandshake =
   /*@__PURE__*/ notImplemented("http2.performServerHandshake ");
 
-export const Http2ServerRequest: typeof http2.Http2ServerRequest =
+export const Http2ServerRequest: typeof nodeHttp2.Http2ServerRequest =
   mock.__createMock__("http2.Http2ServerRequest");
-export const Http2ServerResponse: typeof http2.Http2ServerResponse =
+export const Http2ServerResponse: typeof nodeHttp2.Http2ServerResponse =
   mock.__createMock__("http2.Http2ServerResponse");
 
-export const getDefaultSettings: typeof http2.getDefaultSettings = function () {
-  return Object.create({
-    headerTableSize: 4096,
-    enablePush: true,
-    initialWindowSize: 65_535,
-    maxFrameSize: 16_384,
-    maxConcurrentStreams: 4_294_967_295,
-    maxHeaderSize: 65_535,
-    maxHeaderListSize: 65_535,
-    enableConnectProtocol: false,
-  });
-};
+export const getDefaultSettings: typeof nodeHttp2.getDefaultSettings =
+  function () {
+    return Object.create({
+      headerTableSize: 4096,
+      enablePush: true,
+      initialWindowSize: 65_535,
+      maxFrameSize: 16_384,
+      maxConcurrentStreams: 4_294_967_295,
+      maxHeaderSize: 65_535,
+      maxHeaderListSize: 65_535,
+      enableConnectProtocol: false,
+    });
+  };
 
-export const getPackedSettings: typeof http2.getPackedSettings = function () {
-  return Buffer.from("");
-};
+export const getPackedSettings: typeof nodeHttp2.getPackedSettings =
+  function () {
+    return Buffer.from("");
+  };
 
-export const getUnpackedSettings: typeof http2.getUnpackedSettings =
+export const getUnpackedSettings: typeof nodeHttp2.getUnpackedSettings =
   function () {
     return Object.create({});
   };
 
-export const sensitiveHeaders: typeof http2.sensitiveHeaders = Symbol(
+export const sensitiveHeaders: typeof nodeHttp2.sensitiveHeaders = Symbol(
   "nodejs.http2.sensitiveHeaders",
 );
 
@@ -58,4 +62,4 @@ export default {
   getUnpackedSettings,
   performServerHandshake,
   sensitiveHeaders,
-} satisfies typeof http2;
+} satisfies typeof nodeHttp2;

--- a/src/runtime/node/inspector.ts
+++ b/src/runtime/node/inspector.ts
@@ -1,26 +1,26 @@
 // https://nodejs.org/api/inspector.html
 import noop from "../mock/noop.ts";
 import mock from "../mock/proxy.ts";
-import type inspector from "node:inspector";
+import type nodeInspector from "node:inspector";
 
-export const close: typeof inspector.close = noop;
+export const close: typeof nodeInspector.close = noop;
 
 export const console: Console = mock.__createMock__("inspector.console");
 
-export const open: typeof inspector.open = () => ({
+export const open: typeof nodeInspector.open = () => ({
   __unenv__: true,
   [Symbol.dispose]() {
     return Promise.resolve();
   },
 });
 
-export const url: typeof inspector.url = () => undefined;
+export const url: typeof nodeInspector.url = () => undefined;
 
-export const waitForDebugger: typeof inspector.waitForDebugger = noop;
+export const waitForDebugger: typeof nodeInspector.waitForDebugger = noop;
 
 // `node:inspector` and `node:inspector/promises` share the same implementation with only Session being in the promises module:
 // https://github.com/nodejs/node/blob/main/lib/inspector/promises.js
-export const Session: typeof inspector.Session =
+export const Session: typeof nodeInspector.Session =
   mock.__createMock__("inspector.Session");
 
 export const Network = mock.__createMock__("inspector.Network");
@@ -33,4 +33,4 @@ export default {
   url,
   waitForDebugger,
   Network,
-} satisfies typeof inspector;
+} satisfies typeof nodeInspector;

--- a/src/runtime/node/net.ts
+++ b/src/runtime/node/net.ts
@@ -1,5 +1,5 @@
 // https://nodejs.org/api/net.html
-import type net from "node:net";
+import type nodeNet from "node:net";
 
 import { notImplemented, notImplementedClass } from "../_internal/utils.ts";
 
@@ -17,45 +17,47 @@ export {
 
 export const createServer = /*@__PURE__*/ notImplemented(
   "net.createServer",
-) as typeof net.createServer;
+) as typeof nodeNet.createServer;
 
 export const BlockList = /*@__PURE__*/ notImplementedClass(
   "net.BlockList",
-) as typeof net.BlockList;
+) as typeof nodeNet.BlockList;
 
 export const connect = /*@__PURE__*/ notImplemented(
   "net.connect",
-) as typeof net.connect;
+) as typeof nodeNet.connect;
 
 export const createConnection = /*@__PURE__*/ notImplemented(
   "net.createConnection",
-) as typeof net.createConnection;
+) as typeof nodeNet.createConnection;
 
 export const getDefaultAutoSelectFamily = /*@__PURE__*/ notImplemented(
   "net.getDefaultAutoSelectFamily",
-) as typeof net.getDefaultAutoSelectFamily;
+) as typeof nodeNet.getDefaultAutoSelectFamily;
 
 export const setDefaultAutoSelectFamily = /*@__PURE__*/ notImplemented(
   "net.setDefaultAutoSelectFamily",
-) as typeof net.setDefaultAutoSelectFamily;
+) as typeof nodeNet.setDefaultAutoSelectFamily;
 
 export const getDefaultAutoSelectFamilyAttemptTimeout =
   /*@__PURE__*/ notImplemented(
     "net.getDefaultAutoSelectFamilyAttemptTimeout",
-  ) as typeof net.getDefaultAutoSelectFamilyAttemptTimeout;
+  ) as typeof nodeNet.getDefaultAutoSelectFamilyAttemptTimeout;
 
 export const setDefaultAutoSelectFamilyAttemptTimeout =
   /*@__PURE__*/ notImplemented(
     "net.setDefaultAutoSelectFamilyAttemptTimeout",
-  ) as typeof net.setDefaultAutoSelectFamilyAttemptTimeout;
+  ) as typeof nodeNet.setDefaultAutoSelectFamilyAttemptTimeout;
 
 const IPV4Regex = /^(?:\d{1,3}\.){3}\d{1,3}$/;
-export const isIPv4: typeof net.isIPv4 = (host: string) => IPV4Regex.test(host);
+export const isIPv4: typeof nodeNet.isIPv4 = (host: string) =>
+  IPV4Regex.test(host);
 
 const IPV6Regex = /^([\dA-Fa-f]{1,4}:){7}[\dA-Fa-f]{1,4}$/;
-export const isIPv6: typeof net.isIPv6 = (host: string) => IPV6Regex.test(host);
+export const isIPv6: typeof nodeNet.isIPv6 = (host: string) =>
+  IPV6Regex.test(host);
 
-export const isIP: typeof net.isIP = (host: string) => {
+export const isIP: typeof nodeNet.isIP = (host: string) => {
   if (isIPv4(host)) {
     return 4;
   }
@@ -77,7 +79,7 @@ export const _setSimultaneousAccepts = /*@__PURE__*/ notImplemented(
   "net._setSimultaneousAccepts",
 );
 
-export const exports: typeof net = {
+export const exports: typeof nodeNet = {
   Socket: Socket,
   // @ts-expect-error (deprecated alias)
   Stream: Socket,

--- a/src/runtime/node/os.ts
+++ b/src/runtime/node/os.ts
@@ -1,4 +1,4 @@
-import type os from "node:os";
+import type nodeOs from "node:os";
 import { notImplemented } from "../_internal/utils.ts";
 import { constants } from "./internal/os/constants.ts";
 
@@ -6,14 +6,14 @@ export { constants } from "./internal/os/constants.ts";
 
 const NUM_CPUS = 8;
 
-export const availableParallelism: typeof os.availableParallelism = () =>
+export const availableParallelism: typeof nodeOs.availableParallelism = () =>
   NUM_CPUS;
 
-export const arch: typeof os.arch = () => "";
-export const machine: typeof os.machine = () => "";
-export const endianness: typeof os.endianness = () => "LE";
-export const cpus: typeof os.cpus = () => {
-  const info: os.CpuInfo = {
+export const arch: typeof nodeOs.arch = () => "";
+export const machine: typeof nodeOs.machine = () => "";
+export const endianness: typeof nodeOs.endianness = () => "LE";
+export const cpus: typeof nodeOs.cpus = () => {
+  const info: nodeOs.CpuInfo = {
     model: "",
     speed: 0,
     times: {
@@ -27,21 +27,21 @@ export const cpus: typeof os.cpus = () => {
   return Array.from({ length: NUM_CPUS }, () => info);
 };
 
-export const getPriority: typeof os.getPriority = () => 0;
-export const setPriority: typeof os.setPriority =
-  /*@__PURE__*/ notImplemented<typeof os.setPriority>("os.setPriority");
+export const getPriority: typeof nodeOs.getPriority = () => 0;
+export const setPriority: typeof nodeOs.setPriority =
+  /*@__PURE__*/ notImplemented<typeof nodeOs.setPriority>("os.setPriority");
 
-export const homedir: typeof os.homedir = () => "/";
-export const tmpdir: typeof os.tmpdir = () => "/tmp";
-export const devNull: typeof os.devNull = "/dev/null";
+export const homedir: typeof nodeOs.homedir = () => "/";
+export const tmpdir: typeof nodeOs.tmpdir = () => "/tmp";
+export const devNull: typeof nodeOs.devNull = "/dev/null";
 
-export const freemem: typeof os.freemem = () => 0;
-export const totalmem: typeof os.totalmem = () => 0;
-export const loadavg: typeof os.loadavg = () => [0, 0, 0];
-export const uptime: typeof os.uptime = () => 0;
+export const freemem: typeof nodeOs.freemem = () => 0;
+export const totalmem: typeof nodeOs.totalmem = () => 0;
+export const loadavg: typeof nodeOs.loadavg = () => [0, 0, 0];
+export const uptime: typeof nodeOs.uptime = () => 0;
 
-export const hostname: typeof os.hostname = () => "";
-export const networkInterfaces: typeof os.networkInterfaces = () => {
+export const hostname: typeof nodeOs.hostname = () => "";
+export const networkInterfaces: typeof nodeOs.networkInterfaces = () => {
   return {
     lo0: [
       {
@@ -74,12 +74,12 @@ export const networkInterfaces: typeof os.networkInterfaces = () => {
   };
 };
 
-export const platform: typeof os.platform = () => "linux";
-export const type: typeof os.type = () => "Linux";
-export const release: typeof os.release = () => "";
-export const version: typeof os.version = () => "";
+export const platform: typeof nodeOs.platform = () => "linux";
+export const type: typeof nodeOs.type = () => "Linux";
+export const release: typeof nodeOs.release = () => "";
+export const version: typeof nodeOs.version = () => "";
 
-export const userInfo: typeof os.userInfo = (opts) => {
+export const userInfo: typeof nodeOs.userInfo = (opts) => {
   const encode = (str: string) => {
     if (opts?.encoding) {
       const buff = Buffer.from(str);
@@ -96,7 +96,7 @@ export const userInfo: typeof os.userInfo = (opts) => {
   } as any;
 };
 
-export const EOL: typeof os.EOL = "\n";
+export const EOL: typeof nodeOs.EOL = "\n";
 
 export default {
   arch,
@@ -122,4 +122,4 @@ export default {
   uptime,
   userInfo,
   version,
-} satisfies typeof os;
+} satisfies typeof nodeOs;

--- a/src/runtime/node/perf_hooks.ts
+++ b/src/runtime/node/perf_hooks.ts
@@ -1,4 +1,4 @@
-import type perf_hooks from "node:perf_hooks";
+import type nodePerfHooks from "node:perf_hooks";
 import {
   IntervalHistogram,
   RecordableHistogram,
@@ -18,12 +18,12 @@ export { constants } from "./internal/perf_hooks/constants.ts";
 
 export * from "./internal/perf_hooks/performance.ts";
 
-export const monitorEventLoopDelay: typeof perf_hooks.monitorEventLoopDelay =
+export const monitorEventLoopDelay: typeof nodePerfHooks.monitorEventLoopDelay =
   function (_options) {
     return new IntervalHistogram();
   };
 
-export const createHistogram: typeof perf_hooks.createHistogram = function (
+export const createHistogram: typeof nodePerfHooks.createHistogram = function (
   _options,
 ) {
   return new RecordableHistogram();
@@ -45,4 +45,4 @@ export default {
   createHistogram,
   monitorEventLoopDelay,
   performance,
-} satisfies Omit<typeof perf_hooks, "PerformanceNodeTiming">; // @types/node bug: PerformanceNodeTiming is included in the types but doesn't exist in the runtime
+} satisfies Omit<typeof nodePerfHooks, "PerformanceNodeTiming">; // @types/node bug: PerformanceNodeTiming is included in the types but doesn't exist in the runtime

--- a/src/runtime/node/punycode.ts
+++ b/src/runtime/node/punycode.ts
@@ -1,7 +1,7 @@
-import type punycode from "node:punycode";
+import type nodePunycode from "node:punycode";
 
 import _punycode from "./internal/punycode/punycode.ts";
 
 export * from "./internal/punycode/punycode.ts";
 
-export default _punycode satisfies typeof punycode;
+export default _punycode satisfies typeof nodePunycode;

--- a/src/runtime/node/readline.ts
+++ b/src/runtime/node/readline.ts
@@ -1,5 +1,5 @@
 // https://nodejs.org/api/readline.html#readlineclearlinestream-dir-callback
-import type readline from "node:readline";
+import type nodeReadline from "node:readline";
 import noop from "../mock/noop.ts";
 import promises from "./readline/promises.ts";
 import { Interface } from "./internal/readline/interface.ts";
@@ -7,13 +7,13 @@ import { Interface } from "./internal/readline/interface.ts";
 export * as promises from "./readline/promises.ts";
 export { Interface } from "./internal/readline/interface.ts";
 
-export const clearLine: typeof readline.clearLine = () => false;
-export const clearScreenDown: typeof readline.clearScreenDown = () => false;
-export const createInterface: typeof readline.createInterface = () =>
+export const clearLine: typeof nodeReadline.clearLine = () => false;
+export const clearScreenDown: typeof nodeReadline.clearScreenDown = () => false;
+export const createInterface: typeof nodeReadline.createInterface = () =>
   new Interface();
-export const cursorTo: typeof readline.cursorTo = () => false;
-export const emitKeypressEvents: typeof readline.emitKeypressEvents = noop;
-export const moveCursor: typeof readline.moveCursor = () => false;
+export const cursorTo: typeof nodeReadline.cursorTo = () => false;
+export const emitKeypressEvents: typeof nodeReadline.emitKeypressEvents = noop;
+export const moveCursor: typeof nodeReadline.moveCursor = () => false;
 
 export default {
   Interface,
@@ -25,4 +25,4 @@ export default {
   emitKeypressEvents,
   moveCursor,
   promises,
-} as /* TODO: use satisfies */ typeof readline;
+} as /* TODO: use satisfies */ typeof nodeReadline;

--- a/src/runtime/node/stream.ts
+++ b/src/runtime/node/stream.ts
@@ -1,5 +1,5 @@
 // https://nodejs.org/api/stream.html
-import type stream from "node:stream";
+import type nodeStream from "node:stream";
 import mock from "../mock/proxy.ts";
 import { notImplemented } from "../_internal/utils.ts";
 import { Readable } from "./internal/stream/readable.ts";
@@ -16,18 +16,18 @@ export { Writable } from "./internal/stream/writable.ts";
 export { Duplex } from "./internal/stream/duplex.ts";
 export { Transform } from "./internal/stream/transform.ts";
 
-export const Stream: stream.Stream = mock.__createMock__("Stream");
-export const PassThrough: stream.PassThrough =
+export const Stream: nodeStream.Stream = mock.__createMock__("Stream");
+export const PassThrough: nodeStream.PassThrough =
   mock.__createMock__("PassThrough");
 
-export const pipeline = /*@__PURE__*/ notImplemented<typeof stream.pipeline>(
-  "stream.pipeline",
-) as any;
-export const finished = /*@__PURE__*/ notImplemented<typeof stream.finished>(
-  "stream.finished",
-) as any;
+export const pipeline = /*@__PURE__*/ notImplemented<
+  typeof nodeStream.pipeline
+>("stream.pipeline") as any;
+export const finished = /*@__PURE__*/ notImplemented<
+  typeof nodeStream.finished
+>("stream.finished") as any;
 export const addAbortSignal = /*@__PURE__*/ notImplemented<
-  typeof stream.addAbortSignal
+  typeof nodeStream.addAbortSignal
 >("stream.addAbortSignal");
 
 export const isDisturbed = /*@__PURE__*/ notImplemented("stream.isDisturbed");
@@ -61,12 +61,12 @@ export const setDefaultHighWaterMark = /*@__PURE__*/ notImplemented(
 );
 
 export default {
-  Readable: Readable as unknown as typeof stream.Readable,
-  Writable: Writable as unknown as typeof stream.Writable,
-  Duplex: Duplex as unknown as typeof stream.Duplex,
-  Transform: Transform as unknown as typeof stream.Transform,
-  Stream: Stream as unknown as typeof stream.Stream,
-  PassThrough: PassThrough as unknown as typeof stream.PassThrough,
+  Readable: Readable as unknown as typeof nodeStream.Readable,
+  Writable: Writable as unknown as typeof nodeStream.Writable,
+  Duplex: Duplex as unknown as typeof nodeStream.Duplex,
+  Transform: Transform as unknown as typeof nodeStream.Transform,
+  Stream: Stream as unknown as typeof nodeStream.Stream,
+  PassThrough: PassThrough as unknown as typeof nodeStream.PassThrough,
   pipeline,
   finished,
   addAbortSignal,
@@ -84,7 +84,7 @@ export default {
   isDestroyed,
   isWritable,
   setDefaultHighWaterMark,
-} as /* TODO: use satisfies */ typeof stream & {
+} as /* TODO: use satisfies */ typeof nodeStream & {
   isDisturbed: any;
   isReadable: any;
   compose: any;

--- a/src/runtime/node/string_decoder.ts
+++ b/src/runtime/node/string_decoder.ts
@@ -1,11 +1,11 @@
 // https://nodejs.org/api/string_decoder.html
-import type stringDecoder from "node:string_decoder";
+import type nodeStringDecoder from "node:string_decoder";
 import { notImplementedClass } from "../_internal/utils.ts";
 
-export const StringDecoder: typeof stringDecoder.StringDecoder =
+export const StringDecoder: typeof nodeStringDecoder.StringDecoder =
   (globalThis as any).StringDecoder ||
   /*@__PURE__*/ notImplementedClass("string_decoder.StringDecoder");
 
 export default {
   StringDecoder,
-} satisfies typeof stringDecoder;
+} satisfies typeof nodeStringDecoder;

--- a/src/runtime/node/timers.ts
+++ b/src/runtime/node/timers.ts
@@ -1,6 +1,6 @@
 import { notImplemented } from "../_internal/utils.ts";
 import noop from "../mock/noop.ts";
-import type timers from "node:timers";
+import type nodeTimers from "node:timers";
 import promises from "./timers/promises.ts";
 import { setTimeoutFallback } from "./internal/timers/set-timeout.ts";
 import {
@@ -11,18 +11,18 @@ import { setIntervalFallback } from "./internal/timers/set-interval.ts";
 
 export * as promises from "./timers/promises.ts";
 
-export const clearImmediate: typeof timers.clearImmediate =
+export const clearImmediate: typeof nodeTimers.clearImmediate =
   globalThis.clearImmediate?.bind(globalThis) || clearImmediateFallback;
-export const clearInterval: typeof timers.clearInterval =
+export const clearInterval: typeof nodeTimers.clearInterval =
   globalThis.clearInterval?.bind(globalThis) || noop;
-export const clearTimeout: typeof timers.clearTimeout =
+export const clearTimeout: typeof nodeTimers.clearTimeout =
   globalThis.clearTimeout?.bind(globalThis) || noop;
 
-export const setImmediate: typeof timers.setImmediate =
+export const setImmediate: typeof nodeTimers.setImmediate =
   globalThis.setImmediate?.bind(globalThis) || setImmediateFallback;
-export const setTimeout: typeof timers.setTimeout =
+export const setTimeout: typeof nodeTimers.setTimeout =
   globalThis.setTimeout?.bind(globalThis) || setTimeoutFallback;
-export const setInterval: typeof timers.setInterval =
+export const setInterval: typeof nodeTimers.setInterval =
   globalThis.setInterval?.bind(globalThis) || setIntervalFallback;
 
 export const active = function active(timeout: NodeJS.Timeout | undefined) {
@@ -45,4 +45,4 @@ export default {
   setInterval,
   setTimeout,
   unenroll,
-} satisfies typeof timers;
+} satisfies typeof nodeTimers;

--- a/src/runtime/node/tls.ts
+++ b/src/runtime/node/tls.ts
@@ -1,4 +1,4 @@
-import type tls from "node:tls";
+import type nodeTls from "node:tls";
 import { notImplemented } from "../_internal/utils.ts";
 import { TLSSocket } from "./internal/tls/tls-socket.ts";
 import { Server } from "./internal/tls/server.ts";
@@ -10,26 +10,27 @@ export { TLSSocket } from "./internal/tls/tls-socket.ts";
 export { Server } from "./internal/tls/server.ts";
 export { SecureContext } from "./internal/tls/secure-context.ts";
 
-export const connect: typeof tls.connect = function connect() {
+export const connect: typeof nodeTls.connect = function connect() {
   return new TLSSocket();
 };
 
-export const createServer: typeof tls.createServer = function createServer() {
-  return new Server();
-};
-export const checkServerIdentity: typeof tls.checkServerIdentity =
+export const createServer: typeof nodeTls.createServer =
+  function createServer() {
+    return new Server();
+  };
+export const checkServerIdentity: typeof nodeTls.checkServerIdentity =
   /*@__PURE__*/ notImplemented("tls.checkServerIdentity");
 export const convertALPNProtocols = /*@__PURE__*/ notImplemented(
   "tls.convertALPNProtocols",
 );
-export const createSecureContext: typeof tls.createSecureContext =
+export const createSecureContext: typeof nodeTls.createSecureContext =
   /*@__PURE__*/ notImplemented("tls.createSecureContext");
-export const createSecurePair: typeof tls.createSecurePair =
+export const createSecurePair: typeof nodeTls.createSecurePair =
   /*@__PURE__*/ notImplemented("tls.createSecurePair");
-export const getCiphers: typeof tls.getCiphers =
+export const getCiphers: typeof nodeTls.getCiphers =
   /*@__PURE__*/ notImplemented("tls.getCiphers");
 
-export const rootCertificates: typeof tls.rootCertificates = [];
+export const rootCertificates: typeof nodeTls.rootCertificates = [];
 
 export default {
   ...constants,
@@ -44,4 +45,4 @@ export default {
   createServer,
   getCiphers,
   rootCertificates,
-} as /* TODO: use satisfies */ typeof tls;
+} as /* TODO: use satisfies */ typeof nodeTls;

--- a/src/runtime/node/trace_events.ts
+++ b/src/runtime/node/trace_events.ts
@@ -1,13 +1,13 @@
-import type trace_events from "node:trace_events";
+import type nodeTraceEvents from "node:trace_events";
 import { Tracing } from "./internal/trace_events/tracing.ts";
 
-export const createTracing: typeof trace_events.createTracing = function () {
+export const createTracing: typeof nodeTraceEvents.createTracing = function () {
   return new Tracing();
 };
-export const getEnabledCategories: typeof trace_events.getEnabledCategories =
+export const getEnabledCategories: typeof nodeTraceEvents.getEnabledCategories =
   () => "";
 
 export default {
   createTracing,
   getEnabledCategories,
-} satisfies typeof trace_events;
+} satisfies typeof nodeTraceEvents;

--- a/src/runtime/node/tty.ts
+++ b/src/runtime/node/tty.ts
@@ -1,11 +1,11 @@
-import type tty from "node:tty";
+import type nodeTty from "node:tty";
 import { ReadStream } from "./internal/tty/read-stream.ts";
 import { WriteStream } from "./internal/tty/write-stream.ts";
 
 export { ReadStream } from "./internal/tty/read-stream.ts";
 export { WriteStream } from "./internal/tty/write-stream.ts";
 
-export const isatty: typeof tty.isatty = function () {
+export const isatty: typeof nodeTty.isatty = function () {
   return false;
 };
 
@@ -13,4 +13,4 @@ export default {
   ReadStream,
   WriteStream,
   isatty,
-} satisfies typeof tty;
+} satisfies typeof nodeTty;

--- a/src/runtime/node/util.ts
+++ b/src/runtime/node/util.ts
@@ -1,5 +1,5 @@
 // https://nodejs.org/api/util.html
-import type util from "node:util";
+import type nodeUtil from "node:util";
 import { notImplemented } from "../_internal/utils.ts";
 import inherits from "../npm/inherits.ts";
 import * as legacyTypes from "./internal/util/legacy-types.ts";
@@ -17,12 +17,12 @@ export { promisify } from "./internal/util/promisify.ts";
 export { default as types } from "./util/types.ts";
 
 // @ts-ignore
-export const TextDecoder: typeof util.TextDecoder = globalThis.TextDecoder;
+export const TextDecoder: typeof nodeUtil.TextDecoder = globalThis.TextDecoder;
 
 // @ts-ignore
-export const TextEncoder: typeof util.TextEncoder = globalThis.TextEncoder;
+export const TextEncoder: typeof nodeUtil.TextEncoder = globalThis.TextEncoder;
 
-export const deprecate: typeof util.deprecate = (fn) => fn;
+export const deprecate: typeof nodeUtil.deprecate = (fn) => fn;
 
 export const _errnoException = /*@__PURE__*/ notImplemented(
   "util._errnoException",
@@ -33,44 +33,46 @@ export const _exceptionWithHostPort = /*@__PURE__*/ notImplemented(
 export const _extend = /*@__PURE__*/ notImplemented("util._extend");
 
 export const aborted =
-  /*@__PURE__*/ notImplemented<typeof util.aborted>("util.aborted");
+  /*@__PURE__*/ notImplemented<typeof nodeUtil.aborted>("util.aborted");
 export const callbackify =
-  /*@__PURE__*/ notImplemented<typeof util.callbackify>("util.callbackify");
+  /*@__PURE__*/ notImplemented<typeof nodeUtil.callbackify>("util.callbackify");
 export const getSystemErrorMap = /*@__PURE__*/ notImplemented<
-  typeof util.getSystemErrorMap
+  typeof nodeUtil.getSystemErrorMap
 >("util.getSystemErrorMap");
 export const getSystemErrorName = /*@__PURE__*/ notImplemented<
-  typeof util.getSystemErrorName
+  typeof nodeUtil.getSystemErrorName
 >("util.getSystemErrorName");
 export const toUSVString =
-  /*@__PURE__*/ notImplemented<typeof util.toUSVString>("util.toUSVString");
+  /*@__PURE__*/ notImplemented<typeof nodeUtil.toUSVString>("util.toUSVString");
 export const stripVTControlCharacters = /*@__PURE__*/ notImplemented<
-  typeof util.stripVTControlCharacters
+  typeof nodeUtil.stripVTControlCharacters
 >("util.stripVTControlCharacters");
 
 export const transferableAbortController = /*@__PURE__*/ notImplemented<
-  typeof util.transferableAbortController
+  typeof nodeUtil.transferableAbortController
 >("util.transferableAbortController");
 export const transferableAbortSignal = /*@__PURE__*/ notImplemented<
-  typeof util.transferableAbortSignal
+  typeof nodeUtil.transferableAbortSignal
 >("util.transferableAbortSignal");
 export const parseArgs =
-  /*@__PURE__*/ notImplemented<typeof util.parseArgs>("util.parseArgs");
+  /*@__PURE__*/ notImplemented<typeof nodeUtil.parseArgs>("util.parseArgs");
 
 export const parseEnv =
-  /*@__PURE__*/ notImplemented<typeof util.parseEnv>("util.parseEnv");
+  /*@__PURE__*/ notImplemented<typeof nodeUtil.parseEnv>("util.parseEnv");
 
 export const styleText =
-  /*@__PURE__*/ notImplemented<typeof util.styleText>("util.styleText");
+  /*@__PURE__*/ notImplemented<typeof nodeUtil.styleText>("util.styleText");
 
 /** @deprecated */
 export const getCallSite = /*@__PURE__*/ notImplemented("util.getCallSite");
 
 export const getCallSites =
-  /*@__PURE__*/ notImplemented<typeof util.getCallSites>("util.getCallSites");
+  /*@__PURE__*/ notImplemented<typeof nodeUtil.getCallSites>(
+    "util.getCallSites",
+  );
 
 export const getSystemErrorMessage = /*@__PURE__*/ notImplemented<
-  typeof util.getSystemErrorMessage
+  typeof nodeUtil.getSystemErrorMessage
 >("util.getSystemErrorMessage");
 
 export default {
@@ -100,4 +102,4 @@ export default {
   ...mime,
   ...logUtils,
   ...legacyTypes,
-} as /* TODO: use satisfies */ typeof util;
+} as /* TODO: use satisfies */ typeof nodeUtil;

--- a/src/runtime/node/v8.ts
+++ b/src/runtime/node/v8.ts
@@ -1,5 +1,5 @@
 import noop from "../mock/noop.ts";
-import type v8 from "node:v8";
+import type nodeV8 from "node:v8";
 import { Readable } from "node:stream";
 import {
   Deserializer,
@@ -23,27 +23,29 @@ const getMockHeapSpaceStats = (name: string) => ({
   physical_space_size: 0,
 });
 
-export const cachedDataVersionTag: typeof v8.cachedDataVersionTag = () => 0;
-export const deserialize: typeof v8.deserialize = noop;
-export const getHeapCodeStatistics: typeof v8.getHeapCodeStatistics = () => ({
-  code_and_metadata_size: 0,
-  bytecode_and_metadata_size: 0,
-  external_script_source_size: 0,
-  cpu_profiler_metadata_size: 0,
-});
-export const getHeapSpaceStatistics: typeof v8.getHeapSpaceStatistics = () =>
-  [
-    "read_only_space",
-    "new_space",
-    "old_space",
-    "code_space",
-    "map_space",
-    "large_object_space",
-    "code_large_object_space",
-    "new_large_object_space",
-  ].map((space) => getMockHeapSpaceStats(space));
+export const cachedDataVersionTag: typeof nodeV8.cachedDataVersionTag = () => 0;
+export const deserialize: typeof nodeV8.deserialize = noop;
+export const getHeapCodeStatistics: typeof nodeV8.getHeapCodeStatistics =
+  () => ({
+    code_and_metadata_size: 0,
+    bytecode_and_metadata_size: 0,
+    external_script_source_size: 0,
+    cpu_profiler_metadata_size: 0,
+  });
+export const getHeapSpaceStatistics: typeof nodeV8.getHeapSpaceStatistics =
+  () =>
+    [
+      "read_only_space",
+      "new_space",
+      "old_space",
+      "code_space",
+      "map_space",
+      "large_object_space",
+      "code_large_object_space",
+      "new_large_object_space",
+    ].map((space) => getMockHeapSpaceStats(space));
 
-export const getHeapStatistics: typeof v8.getHeapStatistics = () => ({
+export const getHeapStatistics: typeof nodeV8.getHeapStatistics = () => ({
   total_heap_size: 0,
   total_heap_size_executable: 0,
   total_physical_size: 0,
@@ -60,7 +62,7 @@ export const getHeapStatistics: typeof v8.getHeapStatistics = () => ({
   external_memory: 0,
 });
 
-export const getHeapSnapshot: typeof v8.getHeapSnapshot = () => {
+export const getHeapSnapshot: typeof nodeV8.getHeapSnapshot = () => {
   return Readable.from(`{
     snapshot: {},
     nodes: [],
@@ -73,7 +75,7 @@ export const getHeapSnapshot: typeof v8.getHeapSnapshot = () => {
   }`);
 };
 
-export const promiseHooks: typeof v8.promiseHooks = {
+export const promiseHooks: typeof nodeV8.promiseHooks = {
   onInit: () => noop,
   onSettled: () => noop,
   onBefore: () => noop,
@@ -81,20 +83,20 @@ export const promiseHooks: typeof v8.promiseHooks = {
   createHook: () => noop,
 };
 
-export const serialize: typeof v8.serialize = (value: any) =>
+export const serialize: typeof nodeV8.serialize = (value: any) =>
   Buffer.from(value);
-export const setFlagsFromString: typeof v8.setFlagsFromString = noop;
-export const setHeapSnapshotNearHeapLimit: typeof v8.setHeapSnapshotNearHeapLimit =
+export const setFlagsFromString: typeof nodeV8.setFlagsFromString = noop;
+export const setHeapSnapshotNearHeapLimit: typeof nodeV8.setHeapSnapshotNearHeapLimit =
   noop;
-export const startupSnapshot: typeof v8.startupSnapshot = {
+export const startupSnapshot: typeof nodeV8.startupSnapshot = {
   addDeserializeCallback: noop,
   addSerializeCallback: noop,
   setDeserializeMainFunction: noop,
   isBuildingSnapshot: () => false,
 };
-export const stopCoverage: typeof v8.stopCoverage = noop;
-export const takeCoverage: typeof v8.takeCoverage = noop;
-export const writeHeapSnapshot: typeof v8.writeHeapSnapshot = () => "";
+export const stopCoverage: typeof nodeV8.stopCoverage = noop;
+export const takeCoverage: typeof nodeV8.takeCoverage = noop;
+export const writeHeapSnapshot: typeof nodeV8.writeHeapSnapshot = () => "";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 type _Function = Function;
@@ -138,4 +140,4 @@ export default {
   takeCoverage,
   writeHeapSnapshot,
   queryObjects,
-} satisfies typeof v8;
+} satisfies typeof nodeV8;

--- a/src/runtime/node/vm.ts
+++ b/src/runtime/node/vm.ts
@@ -1,4 +1,4 @@
-import type vm from "node:vm";
+import type nodeVm from "node:vm";
 import { notImplemented } from "../_internal/utils.ts";
 import { Script } from "./internal/vm/script.ts";
 import * as constants from "./internal/vm/constants.ts";
@@ -6,40 +6,41 @@ import * as constants from "./internal/vm/constants.ts";
 export { Script } from "./internal/vm/script.ts";
 export * as constants from "./internal/vm/constants.ts";
 
-export const compileFunction: typeof vm.compileFunction =
+export const compileFunction: typeof nodeVm.compileFunction =
   /*@__PURE__*/ notImplemented("vm.compileFunction");
 
 const _contextSymbol = Symbol("uenv.vm.context");
 
-export const createContext: typeof vm.createContext = function createContext() {
-  return Object.create(null, {
-    [_contextSymbol]: {
-      value: true,
-    },
-  });
-};
+export const createContext: typeof nodeVm.createContext =
+  function createContext() {
+    return Object.create(null, {
+      [_contextSymbol]: {
+        value: true,
+      },
+    });
+  };
 
 export const createScript = function createScript() {
   return new Script();
 };
 
-export const isContext: typeof vm.isContext = (context) => {
+export const isContext: typeof nodeVm.isContext = (context) => {
   return context && context[_contextSymbol as any] === true;
 };
 
-export const measureMemory: typeof vm.measureMemory = () =>
+export const measureMemory: typeof nodeVm.measureMemory = () =>
   Promise.resolve({
     total: { jsMemoryEstimate: 0, jsMemoryRange: [1, 2] },
     WebAssembly: { code: 0, metadata: 0 },
   });
 
-export const runInContext: typeof vm.runInContext =
+export const runInContext: typeof nodeVm.runInContext =
   /*@__PURE__*/ notImplemented("vm.runInContext");
 
-export const runInNewContext: typeof vm.runInNewContext =
+export const runInNewContext: typeof nodeVm.runInNewContext =
   /*@__PURE__*/ notImplemented("vm.runInNewContext");
 
-export const runInThisContext: typeof vm.runInThisContext =
+export const runInThisContext: typeof nodeVm.runInThisContext =
   /*@__PURE__*/ notImplemented("vm.runInThisContext");
 
 export default {
@@ -54,6 +55,6 @@ export default {
   runInNewContext,
   runInThisContext,
 } as /* TODO: use satisfies */ Omit<
-  typeof vm,
+  typeof nodeVm,
   "Module" | "SourceTextModule" | "SyntheticModule"
 >;

--- a/src/runtime/node/wasi.ts
+++ b/src/runtime/node/wasi.ts
@@ -1,9 +1,9 @@
-import type wasi from "node:wasi";
+import type nodeWasi from "node:wasi";
 import { notImplementedClass } from "../_internal/utils.ts";
 
-export const WASI: typeof wasi.WASI =
+export const WASI: typeof nodeWasi.WASI =
   /*@__PURE__*/ notImplementedClass("wasi.WASI");
 
 export default {
   WASI,
-} satisfies typeof wasi;
+} satisfies typeof nodeWasi;

--- a/src/runtime/node/worker_threads.ts
+++ b/src/runtime/node/worker_threads.ts
@@ -1,4 +1,4 @@
-import type worker_threads from "node:worker_threads";
+import type nodeWorkerThreads from "node:worker_threads";
 import { BroadcastChannel } from "./internal/worker_threads/broadcast-channel.ts";
 import { MessageChannel } from "./internal/worker_threads/message-channel.ts";
 import { MessagePort } from "./internal/worker_threads/message-port.ts";
@@ -11,46 +11,46 @@ export { MessageChannel } from "./internal/worker_threads/message-channel.ts";
 export { MessagePort } from "./internal/worker_threads/message-port.ts";
 export { Worker } from "./internal/worker_threads/worker.ts";
 
-const _environmentData = new Map<string, worker_threads.Serializable>();
-export const getEnvironmentData: typeof worker_threads.getEnvironmentData =
+const _environmentData = new Map<string, nodeWorkerThreads.Serializable>();
+export const getEnvironmentData: typeof nodeWorkerThreads.getEnvironmentData =
   function getEnvironmentData(key) {
     return _environmentData.get(key as string)!;
   };
-export const setEnvironmentData: typeof worker_threads.setEnvironmentData =
+export const setEnvironmentData: typeof nodeWorkerThreads.setEnvironmentData =
   function setEnvironmentData(key, value) {
     _environmentData.set(key as string, value);
   };
 
-export const isMainThread: typeof worker_threads.isMainThread = true;
+export const isMainThread: typeof nodeWorkerThreads.isMainThread = true;
 
 export const isMarkedAsUntransferable: any /* Node.js 22 */ = () => false;
-export const markAsUntransferable: typeof worker_threads.markAsUntransferable =
+export const markAsUntransferable: typeof nodeWorkerThreads.markAsUntransferable =
   function markAsUntransferable(value) {
     // noop
   };
 
-export const markAsUncloneable: typeof worker_threads.markAsUncloneable =
+export const markAsUncloneable: typeof nodeWorkerThreads.markAsUncloneable =
   () => {
     // noop
   };
 
-export const moveMessagePortToContext: typeof worker_threads.moveMessagePortToContext =
+export const moveMessagePortToContext: typeof nodeWorkerThreads.moveMessagePortToContext =
   () => new MessagePort();
 
-export const parentPort: typeof worker_threads.parentPort = null;
+export const parentPort: typeof nodeWorkerThreads.parentPort = null;
 
-export const receiveMessageOnPort: typeof worker_threads.receiveMessageOnPort =
+export const receiveMessageOnPort: typeof nodeWorkerThreads.receiveMessageOnPort =
   () => undefined;
 
 export const SHARE_ENV = Symbol.for(
   "nodejs.worker_threads.SHARE_ENV",
-) as typeof worker_threads.SHARE_ENV;
+) as typeof nodeWorkerThreads.SHARE_ENV;
 
-export const resourceLimits: typeof worker_threads.resourceLimits = {};
+export const resourceLimits: typeof nodeWorkerThreads.resourceLimits = {};
 
-export const threadId: typeof worker_threads.threadId = 0;
+export const threadId: typeof nodeWorkerThreads.threadId = 0;
 
-export const workerData: typeof worker_threads.workerData = null;
+export const workerData: typeof nodeWorkerThreads.workerData = null;
 
 // https://nodejs.org/api/worker_threads.html#workerpostmessagetothreadthreadid-value-transferlist-timeout
 export const postMessageToThread = /*@__PURE__*/ notImplemented(
@@ -76,4 +76,4 @@ export default {
   postMessageToThread,
   threadId,
   workerData,
-} as /* TODO: use satisfies */ typeof worker_threads;
+} as /* TODO: use satisfies */ typeof nodeWorkerThreads;

--- a/src/runtime/node/zlib.ts
+++ b/src/runtime/node/zlib.ts
@@ -1,4 +1,4 @@
-import type zlib from "node:zlib";
+import type nodeZlib from "node:zlib";
 
 import { constants } from "./internal/zlib/constants.ts";
 import { codes } from "./internal/zlib/codes.ts";
@@ -18,14 +18,14 @@ export * from "./internal/zlib/formats/gzip.ts";
 export * from "./internal/zlib/formats/zip.ts";
 
 export const crc32 =
-  /*@__PURE__*/ notImplemented<typeof zlib.crc32>("zlib.crc32");
+  /*@__PURE__*/ notImplemented<typeof nodeZlib.crc32>("zlib.crc32");
 
 // Deprecated constants
-const Z_BINARY: typeof zlib.Z_BINARY = 0;
-const Z_TEXT: typeof zlib.Z_TEXT = 1;
-const Z_ASCII: typeof zlib.Z_ASCII = 1;
-const Z_UNKNOWN: typeof zlib.Z_UNKNOWN = 2;
-const Z_DEFLATED: typeof zlib.Z_DEFLATED = 8;
+const Z_BINARY: typeof nodeZlib.Z_BINARY = 0;
+const Z_TEXT: typeof nodeZlib.Z_TEXT = 1;
+const Z_ASCII: typeof nodeZlib.Z_ASCII = 1;
+const Z_UNKNOWN: typeof nodeZlib.Z_UNKNOWN = 2;
+const Z_DEFLATED: typeof nodeZlib.Z_DEFLATED = 8;
 
 export default {
   ...constants,
@@ -42,4 +42,4 @@ export default {
   Z_ASCII,
   Z_UNKNOWN,
   Z_DEFLATED,
-} satisfies typeof zlib;
+} satisfies typeof nodeZlib;


### PR DESCRIPTION
minor change.

`assert` was node importing the type only.

Took the opportunity to unify all node type imports