### PR TITLE
refactor!: avoid proxy mock usage

### DIFF
--- a/src/runtime/node/cluster.ts
+++ b/src/runtime/node/cluster.ts
@@ -1,12 +1,10 @@
-// Reference: https://github.com/nodejs/node/blob/main/lib/internal/cluster/primary.js
-import mock from "../mock/proxy.ts";
-import { notImplemented } from "../_internal/utils.ts";
 import type nodeCluster from "node:cluster";
 import type {
   Cluster as NodeCluster,
   Worker as NodeClusterWorker,
 } from "node:cluster";
 import { EventEmitter } from "node:events";
+import { notImplemented } from "../_internal/utils.ts";
 
 export const SCHED_NONE: typeof nodeCluster.SCHED_NONE = 1;
 export const SCHED_RR: typeof nodeCluster.SCHED_RR = 2;
@@ -40,7 +38,7 @@ export class Worker extends EventEmitter implements NodeClusterWorker {
   _connected: boolean = false;
   id = 0;
   get process() {
-    return mock.process;
+    return globalThis.process as any;
   }
   get exitedAfterDisconnect() {
     return this._connected;

--- a/src/runtime/node/console.ts
+++ b/src/runtime/node/console.ts
@@ -1,8 +1,7 @@
 import type nodeConsole from "node:console";
 import { Writable } from "node:stream";
-import mock from "../mock/proxy.ts";
 import noop from "../mock/noop.ts";
-import { notImplemented } from "../_internal/utils.ts";
+import { notImplemented, notImplementedClass } from "../_internal/utils.ts";
 
 const _console = globalThis.console;
 
@@ -48,9 +47,9 @@ export const timeStamp: typeof nodeConsole.timeStamp =
   _console?.timeStamp ?? noop;
 
 export const Console: typeof nodeConsole.Console =
-  _console?.Console ?? mock.__createMock__("console.Console");
+  _console?.Console ?? /*@__PURE__*/ notImplementedClass("console.Console");
 
-export { default as _times } from "../mock/proxy.ts";
+export const _time = /*@__PURE__*/ new Map();
 
 export function context() {
   // TODO: Should be Console with all the methods

--- a/src/runtime/node/dns.ts
+++ b/src/runtime/node/dns.ts
@@ -1,6 +1,9 @@
 import noop from "../mock/noop.ts";
-import mock from "../mock/proxy.ts";
-import { notImplemented, notImplementedAsync } from "../_internal/utils.ts";
+import {
+  notImplemented,
+  notImplementedAsync,
+  notImplementedClass,
+} from "../_internal/utils.ts";
 import type nodeDns from "node:dns";
 import promises from "./dns/promises.ts";
 import * as constants from "./internal/dns/constants.ts";
@@ -9,7 +12,8 @@ export * from "./internal/dns/constants.ts";
 export * as promises from "./dns/promises.ts";
 
 export const Resolver: typeof nodeDns.Resolver =
-  mock.__createMock__("dns.Resolver");
+  /*@__PURE__*/ notImplementedClass("dns.Resolver");
+
 export const getDefaultResultOrder: typeof nodeDns.getDefaultResultOrder = () =>
   "verbatim";
 export const getServers: typeof nodeDns.getServers = () => [];

--- a/src/runtime/node/dns/promises.ts
+++ b/src/runtime/node/dns/promises.ts
@@ -1,49 +1,71 @@
 import noop from "../../mock/noop.ts";
-import mock from "../../mock/proxy.ts";
-import { notImplemented, notImplementedAsync } from "../../_internal/utils.ts";
+import {
+  notImplemented,
+  notImplementedAsync,
+  notImplementedClass,
+} from "../../_internal/utils.ts";
 import type dns from "node:dns/promises";
 import * as constants from "../internal/dns/constants.ts";
 export * from "../internal/dns/constants.ts";
 
 export const Resolver: typeof dns.Resolver =
-  mock.__createMock__("dns.Resolver");
+  /*@__PURE__*/ notImplementedClass("dns.Resolver");
+
 export const getDefaultResultOrder: typeof dns.getDefaultResultOrder = () =>
   "verbatim";
+
 export const getServers: typeof dns.getServers = () => [];
+
 export const lookup: typeof dns.lookup =
   /*@__PURE__*/ notImplementedAsync("dns.lookup");
+
 export const lookupService: typeof dns.lookupService =
   /*@__PURE__*/ notImplementedAsync("dns.lookupService");
+
 export const resolve: typeof dns.resolve =
   /*@__PURE__*/ notImplementedAsync("dns.resolve");
+
 export const resolve4: typeof dns.resolve4 =
   /*@__PURE__*/ notImplementedAsync("dns.resolve4");
+
 export const resolve6: typeof dns.resolve6 =
   /*@__PURE__*/ notImplementedAsync("dns.resolve6");
+
 export const resolveAny: typeof dns.resolveAny =
   /*@__PURE__*/ notImplementedAsync("dns.resolveAny");
+
 export const resolveCaa: typeof dns.resolveCaa =
   /*@__PURE__*/ notImplementedAsync("dns.resolveCaa");
+
 export const resolveCname: typeof dns.resolveCname =
   /*@__PURE__*/ notImplementedAsync("dns.resolveCname");
+
 export const resolveMx: typeof dns.resolveMx =
   /*@__PURE__*/ notImplementedAsync("dns.resolveMx");
+
 export const resolveNaptr: typeof dns.resolveNaptr =
   /*@__PURE__*/ notImplementedAsync("dns.resolveNaptr");
+
 export const resolveNs: typeof dns.resolveNs =
   /*@__PURE__*/ notImplementedAsync("dns.resolveNs");
+
 export const resolvePtr: typeof dns.resolvePtr =
   /*@__PURE__*/ notImplementedAsync("dns.resolvePtr");
+
 export const resolveSoa: typeof dns.resolveSoa =
   /*@__PURE__*/ notImplementedAsync("dns.resolveSoa");
+
 export const resolveSrv: typeof dns.resolveSrv =
   /*@__PURE__*/ notImplementedAsync("dns.resolveSrv");
+
 export const resolveTxt: typeof dns.resolveTxt =
   /*@__PURE__*/ notImplementedAsync("dns.resolveTxt");
 
 export const reverse: typeof dns.reverse =
   /*@__PURE__*/ notImplemented("dns.reverse");
+
 export const setDefaultResultOrder: typeof dns.setDefaultResultOrder = noop;
+
 export const setServers: typeof dns.setServers = noop;
 
 export default {

--- a/src/runtime/node/http.ts
+++ b/src/runtime/node/http.ts
@@ -4,10 +4,12 @@ import { notImplemented, notImplementedClass } from "../_internal/utils.ts";
 import * as consts from "./internal/http/consts.ts";
 import { IncomingMessage } from "./internal/http/request.ts";
 import { ServerResponse } from "./internal/http/response.ts";
+import { Agent } from "./internal/http/agent.ts";
 
 export * from "./internal/http/consts.ts";
 export * from "./internal/http/request.ts";
 export * from "./internal/http/response.ts";
+export { Agent } from "./internal/http/agent.ts";
 
 export const createServer =
   /*@__PURE__*/ notImplemented<typeof nodeHttp.createServer>(
@@ -26,9 +28,6 @@ export const OutgoingMessage: typeof nodeHttp.OutgoingMessage =
 
 export const ClientRequest: typeof nodeHttp.ClientRequest =
   /*@__PURE__*/ notImplementedClass("http.ClientRequest");
-
-export const Agent: typeof nodeHttp.Agent =
-  /*@__PURE__*/ notImplementedClass("http.Agent");
 
 export const globalAgent: typeof nodeHttp.globalAgent = new Agent();
 

--- a/src/runtime/node/http.ts
+++ b/src/runtime/node/http.ts
@@ -1,7 +1,6 @@
 // https://nodejs.org/api/http.html
 import type nodeHttp from "node:http";
 import { notImplemented, notImplementedClass } from "../_internal/utils.ts";
-import mock from "../mock/proxy.ts";
 import * as consts from "./internal/http/consts.ts";
 import { IncomingMessage } from "./internal/http/request.ts";
 import { ServerResponse } from "./internal/http/response.ts";
@@ -20,15 +19,16 @@ export const get =
   /*@__PURE__*/ notImplemented<typeof nodeHttp.get>("http.get");
 
 export const Server: typeof nodeHttp.Server =
-  mock.__createMock__("http.Server");
+  /*@__PURE__*/ notImplementedClass("http.Server");
 
 export const OutgoingMessage: typeof nodeHttp.OutgoingMessage =
-  mock.__createMock__("http.OutgoingMessage");
+  /*@__PURE__*/ notImplementedClass("http.OutgoingMessage");
 
 export const ClientRequest: typeof nodeHttp.ClientRequest =
-  mock.__createMock__("http.ClientRequest");
+  /*@__PURE__*/ notImplementedClass("http.ClientRequest");
 
-export const Agent: typeof nodeHttp.Agent = mock.__createMock__("http.Agent");
+export const Agent: typeof nodeHttp.Agent =
+  /*@__PURE__*/ notImplementedClass("http.Agent");
 
 export const globalAgent: typeof nodeHttp.globalAgent = new Agent();
 

--- a/src/runtime/node/http2.ts
+++ b/src/runtime/node/http2.ts
@@ -1,6 +1,5 @@
-import mock from "../mock/proxy.ts";
 import type nodeHttp2 from "node:http2";
-import { notImplemented } from "../_internal/utils.ts";
+import { notImplemented, notImplementedClass } from "../_internal/utils.ts";
 import { constants } from "./internal/http2/constants.ts";
 
 export { constants } from "./internal/http2/constants.ts";
@@ -8,19 +7,23 @@ export { constants } from "./internal/http2/constants.ts";
 export const createSecureServer = /*@__PURE__*/ notImplemented<
   typeof nodeHttp2.createSecureServer
 >("http2.createSecureServer");
+
 export const createServer =
   /*@__PURE__*/ notImplemented<typeof nodeHttp2.createServer>(
     "http2.createServer",
   );
+
 export const connect: typeof nodeHttp2.connect =
   /*@__PURE__*/ notImplemented("http2.connect");
+
 export const performServerHandshake: typeof nodeHttp2.performServerHandshake =
   /*@__PURE__*/ notImplemented("http2.performServerHandshake ");
 
 export const Http2ServerRequest: typeof nodeHttp2.Http2ServerRequest =
-  mock.__createMock__("http2.Http2ServerRequest");
+  /*@__PURE__*/ notImplementedClass("http2.Http2ServerRequest");
+
 export const Http2ServerResponse: typeof nodeHttp2.Http2ServerResponse =
-  mock.__createMock__("http2.Http2ServerResponse");
+  /*@__PURE__*/ notImplementedClass("http2.Http2ServerResponse");
 
 export const getDefaultSettings: typeof nodeHttp2.getDefaultSettings =
   function () {

--- a/src/runtime/node/https.ts
+++ b/src/runtime/node/https.ts
@@ -1,12 +1,13 @@
 // https://nodejs.org/api/https.html
 import type nodeHttps from "node:https";
 import { notImplemented, notImplementedClass } from "../_internal/utils.ts";
+import { Agent as HttpAgent } from "./internal/http/agent.ts";
 
 export const Server: typeof nodeHttps.Server =
   /*@__PURE__*/ notImplementedClass("https.Server");
 
 export const Agent: typeof nodeHttps.Agent =
-  /*@__PURE__*/ notImplementedClass("https.Agent");
+  HttpAgent as unknown as typeof nodeHttps.Agent;
 
 export const globalAgent: typeof nodeHttps.globalAgent =
   /*@__PURE__*/ new Agent();

--- a/src/runtime/node/https.ts
+++ b/src/runtime/node/https.ts
@@ -1,13 +1,15 @@
 // https://nodejs.org/api/https.html
 import type nodeHttps from "node:https";
 import { notImplemented, notImplementedClass } from "../_internal/utils.ts";
-import mock from "../mock/proxy.ts";
 
 export const Server: typeof nodeHttps.Server =
   /*@__PURE__*/ notImplementedClass("https.Server");
 
-export const Agent: typeof nodeHttps.Agent = mock.__createMock__("https.Agent");
-export const globalAgent: typeof nodeHttps.globalAgent = new Agent();
+export const Agent: typeof nodeHttps.Agent =
+  /*@__PURE__*/ notImplementedClass("https.Agent");
+
+export const globalAgent: typeof nodeHttps.globalAgent =
+  /*@__PURE__*/ new Agent();
 
 export const get =
   /*@__PURE__*/ notImplemented<typeof nodeHttps.get>("https.get");

--- a/src/runtime/node/inspector.ts
+++ b/src/runtime/node/inspector.ts
@@ -1,11 +1,33 @@
 // https://nodejs.org/api/inspector.html
+import { notImplementedClass, notImplemented } from "../_internal/utils.ts";
 import noop from "../mock/noop.ts";
-import mock from "../mock/proxy.ts";
 import type nodeInspector from "node:inspector";
 
 export const close: typeof nodeInspector.close = noop;
 
-export const console: Console = mock.__createMock__("inspector.console");
+export const console: nodeInspector.InspectorConsole = {
+  debug: noop,
+  error: noop,
+  info: noop,
+  log: noop,
+  warn: noop,
+  dir: noop,
+  dirxml: noop,
+  table: noop,
+  trace: noop,
+  group: noop,
+  groupCollapsed: noop,
+  groupEnd: noop,
+  clear: noop,
+  count: noop,
+  countReset: noop,
+  assert: noop,
+  profile: noop,
+  profileEnd: noop,
+  time: noop,
+  timeLog: noop,
+  timeStamp: noop,
+};
 
 export const open: typeof nodeInspector.open = () => ({
   __unenv__: true,
@@ -21,9 +43,22 @@ export const waitForDebugger: typeof nodeInspector.waitForDebugger = noop;
 // `node:inspector` and `node:inspector/promises` share the same implementation with only Session being in the promises module:
 // https://github.com/nodejs/node/blob/main/lib/inspector/promises.js
 export const Session: typeof nodeInspector.Session =
-  mock.__createMock__("inspector.Session");
+  /*@__PURE__*/ notImplementedClass("inspector.Session");
 
-export const Network = mock.__createMock__("inspector.Network");
+export const Network: typeof nodeInspector.Network = /*@__PURE__*/ {
+  loadingFailed: /*@__PURE__*/ notImplemented(
+    "inspector.Network.loadingFailed",
+  ),
+  loadingFinished: /*@__PURE__*/ notImplemented(
+    "inspector.Network.loadingFinished",
+  ),
+  requestWillBeSent: /*@__PURE__*/ notImplemented(
+    "inspector.Network.requestWillBeSent",
+  ),
+  responseReceived: /*@__PURE__*/ notImplemented(
+    "inspector.Network.responseReceived",
+  ),
+};
 
 export default {
   Session,

--- a/src/runtime/node/inspector/promises.ts
+++ b/src/runtime/node/inspector/promises.ts
@@ -1,9 +1,9 @@
 import type inspectorPromises from "node:inspector/promises";
 import { notImplemented, notImplementedClass } from "../../_internal/utils.ts";
 
-import { console as inspectorConsole } from "../inspector";
+import { console as inspectorConsole } from "../inspector.ts";
 
-export { console } from "../inspector";
+export { console } from "../inspector.ts";
 
 export const Network = /*@__PURE__*/ notImplementedClass<
   typeof inspectorPromises.Network

--- a/src/runtime/node/inspector/promises.ts
+++ b/src/runtime/node/inspector/promises.ts
@@ -1,10 +1,9 @@
 import type inspectorPromises from "node:inspector/promises";
-import mock from "../../mock/proxy.ts";
 import { notImplemented, notImplementedClass } from "../../_internal/utils.ts";
 
-export const console: Console = /*@__PURE__*/ mock.__createMock__(
-  "inspectorPromises.console",
-);
+import { console as inspectorConsole } from "../inspector";
+
+export { console } from "../inspector";
 
 export const Network = /*@__PURE__*/ notImplementedClass<
   typeof inspectorPromises.Network
@@ -32,7 +31,7 @@ export const close = /*@__PURE__*/ notImplemented<
 
 export default {
   close,
-  console,
+  console: inspectorConsole,
   Network,
   open,
   Session,

--- a/src/runtime/node/internal/fs/classes.ts
+++ b/src/runtime/node/internal/fs/classes.ts
@@ -1,20 +1,25 @@
 import type fs from "node:fs";
-import mock from "../../../mock/proxy.ts";
+import { notImplementedClass } from "../../../_internal/utils.ts";
 
-export const Dir: typeof fs.Dir = mock.__createMock__("fs.Dir");
+export const Dir: typeof fs.Dir = /*@__PURE__*/ notImplementedClass("fs.Dir");
 
-export const Dirent: typeof fs.Dirent = mock.__createMock__("fs.Dirent");
+export const Dirent: typeof fs.Dirent =
+  /*@__PURE__*/ notImplementedClass("fs.Dirent");
 
-export const Stats: typeof fs.Stats = mock.__createMock__("fs.Stats");
+export const Stats: typeof fs.Stats =
+  /*@__PURE__*/ notImplementedClass("fs.Stats");
 
 export const ReadStream: typeof fs.ReadStream =
-  mock.__createMock__("fs.ReadStream");
+  /*@__PURE__*/ notImplementedClass("fs.ReadStream");
 
 export const WriteStream: typeof fs.WriteStream =
-  mock.__createMock__("fs.WriteStream");
+  /*@__PURE__*/ notImplementedClass("fs.WriteStream");
 
-export const FileReadStream = mock.__createMock__("fs.FileReadStream");
+export const StatsFs: typeof fs.StatsFs =
+  /*@__PURE__*/ notImplementedClass("fs.StatsFs");
 
-export const FileWriteStream = mock.__createMock__("fs.FileWriteStream");
+export const FileReadStream =
+  /*@__PURE__*/ notImplementedClass("fs.FileReadStream"); // TODO: Does this exists??
 
-export const StatsFs: typeof fs.StatsFs = mock.__createMock__("fs.StatsFs");
+export const FileWriteStream =
+  /*@__PURE__*/ notImplementedClass("fs.FileWriteStream"); // TODO: Does this exists??

--- a/src/runtime/node/internal/http/agent.ts
+++ b/src/runtime/node/internal/http/agent.ts
@@ -1,0 +1,13 @@
+import type http from "node:http";
+import { EventEmitter } from "node:events";
+
+export class Agent extends EventEmitter implements http.Agent {
+  public __unenv__ = {};
+  maxFreeSockets = 256;
+  maxSockets: number = Infinity;
+  maxTotalSockets: number = Infinity;
+  readonly freeSockets = {};
+  readonly sockets = {};
+  readonly requests = {};
+  destroy(): void {}
+}

--- a/src/runtime/node/stream.ts
+++ b/src/runtime/node/stream.ts
@@ -1,7 +1,6 @@
 // https://nodejs.org/api/stream.html
 import type nodeStream from "node:stream";
-import mock from "../mock/proxy.ts";
-import { notImplemented } from "../_internal/utils.ts";
+import { notImplemented, notImplementedClass } from "../_internal/utils.ts";
 import { Readable } from "./internal/stream/readable.ts";
 import { Writable } from "./internal/stream/writable.ts";
 import { Duplex } from "./internal/stream/duplex.ts";
@@ -16,28 +15,38 @@ export { Writable } from "./internal/stream/writable.ts";
 export { Duplex } from "./internal/stream/duplex.ts";
 export { Transform } from "./internal/stream/transform.ts";
 
-export const Stream: nodeStream.Stream = mock.__createMock__("Stream");
+export const Stream: nodeStream.Stream =
+  /*@__PURE__*/ notImplementedClass("stream.Stream");
+
 export const PassThrough: nodeStream.PassThrough =
-  mock.__createMock__("PassThrough");
+  /*@__PURE__*/ notImplementedClass("PassThrough");
 
 export const pipeline = /*@__PURE__*/ notImplemented<
   typeof nodeStream.pipeline
 >("stream.pipeline") as any;
+
 export const finished = /*@__PURE__*/ notImplemented<
   typeof nodeStream.finished
 >("stream.finished") as any;
+
 export const addAbortSignal = /*@__PURE__*/ notImplemented<
   typeof nodeStream.addAbortSignal
 >("stream.addAbortSignal");
 
 export const isDisturbed = /*@__PURE__*/ notImplemented("stream.isDisturbed");
+
 export const isReadable = /*@__PURE__*/ notImplemented("stream.isReadable");
+
 export const compose = /*@__PURE__*/ notImplemented("stream.compose");
+
 export const isErrored = /*@__PURE__*/ notImplemented("stream.isErrored");
+
 export const destroy = /*@__PURE__*/ notImplemented("stream.destroy");
+
 export const _isUint8Array = /*@__PURE__*/ notImplemented(
   "stream._isUint8Array",
 );
+
 export const _uint8ArrayToBuffer = /*@__PURE__*/ notImplemented(
   "stream._uint8ArrayToBuffer",
 );

--- a/src/runtime/web/performance/_performance.ts
+++ b/src/runtime/web/performance/_performance.ts
@@ -1,5 +1,4 @@
 import { createNotImplementedError } from "../../_internal/utils.ts";
-import mock from "../../mock/proxy.ts";
 import { _PerformanceMark, _PerformanceMeasure } from "./_entry.ts";
 
 const _timeOrigin = Date.now();
@@ -18,8 +17,8 @@ export class _Performance<
   _entries: PerformanceEntry[] = [];
   _resourceTimingBufferSize = 0;
 
-  navigation = mock.__createMock__("PerformanceNavigation");
-  timing = mock.__createMock__("PerformanceTiming");
+  navigation = undefined as any;
+  timing = undefined as any;
 
   onresourcetimingbufferfull: ((this: Performance, ev: Event) => any) | null =
     null;


### PR DESCRIPTION
Proxy-based mocks are dangerous and can cause implicit behaviors in libraries.

Since we have migrated almost everything to explicit APIs for v2, this PR updates a few last places to use `notImplementedClass`. (this can cause some breaking changes however this way we can catch those usages and explicitly implement the desired behavior).

As part of migration implemented `http.Agent` polyfill (to polyfill `globalAgent` exports)

/cc @anonrig @vicb  