### PR TITLE
refactor!: add all npm shims with opt-in `npmShims`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ The `defineEnv` utility can generate a target environment configuration.
 import { defineEnv } from "unenv";
 
 const { env } = defineEnv({
-  /* options */
+  nodeCompat: true,
+  npmShims: true,
+  resolve: true,
+  overrides: {},
+  presets: [],
 });
 
 const { alias, inject, external, polyfill } = env;
@@ -51,26 +55,25 @@ You can then integrate the env object with your build tool:
 ### Options
 
 - `nodeCompat`: (default: `true`)
-   - Add `alias` entries for Node.js builtins as `<id>` and `node:<id>`.
-   - Add `inject` entries for Node.js globals `global`, `Buffer`, and `process`.
-- `npmShims`: (default: `true`)
-   - Add `alias` entries to replace npm packages like `node-fetch` with lighter shims.
+  - Add `alias` entries for Node.js builtins as `<id>` and `node:<id>`.
+  - Add `inject` entries for Node.js globals `global`, `Buffer`, and `process`.
+- `npmShims`: (default: `false`)
+  - Add `alias` entries to replace npm packages like `node-fetch` with lighter shims.
 - `resolve`: (default: `false`) Resolve config values to absolute paths.
 - `overrides`: Additional overrides for env config.
 - `presets`: Additional presets (for example [`@cloudflare/unenv-preset`](https://npmjs.com/@cloudflare/unenv-preset/)).
-
 
 ### `unenv/` polyfills
 
 You can also directly import `unenv/` polyfills:
 
-| Polyfills        | Description                                | Source                                                                                 |
-| ---------------- | ------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `unenv/mock/*`   | Mocking utils                              | [`src/runtime/mock/`](https://github.com/unjs/unenv/tree/main/src/runtime/mock)         |
-| `unenv/node/*`   | APIs compatible with `Node.js` API         | [`src/runtime/node/`](https://github.com/unjs/unenv/tree/main/src/runtime/node)         |
-| `unenv/npm/*`      | NPM package shims | [`src/runtime/npm`](https://github.com/unjs/unenv/tree/main/src/runtime/npm)          |
-| `unenv/polyfill/*` | Global polyfills                           | [`src/runtime/polyfill/`](https://github.com/unjs/unenv/tree/main/src/runtime/polyfill) |
-| `unenv/web/*`      | Subset of Web APIs                         | [`src/runtime/web/`](https://github.com/unjs/unenv/tree/main/src/runtime/web)           |
+| Polyfills          | Description                        | Source                                                                                 |
+| ------------------ | ---------------------------------- | -------------------------------------------------------------------------------------- |
+| `unenv/mock/*`     | Mocking utils                      | [`src/runtime/mock`](https://github.com/unjs/unenv/tree/main/src/runtime/mock)         |
+| `unenv/node/*`     | APIs compatible with `Node.js` API | [`src/runtime/node`](https://github.com/unjs/unenv/tree/main/src/runtime/node)         |
+| `unenv/npm/*`      | NPM package shims                  | [`src/runtime/npm`](https://github.com/unjs/unenv/tree/main/src/runtime/npm)           |
+| `unenv/polyfill/*` | Global polyfills                   | [`src/runtime/polyfill`](https://github.com/unjs/unenv/tree/main/src/runtime/polyfill) |
+| `unenv/web/*`      | Subset of Web APIs                 | [`src/runtime/web`](https://github.com/unjs/unenv/tree/main/src/runtime/web)           |
 
 ## Node.js compatibility
 
@@ -139,7 +142,7 @@ You can also directly import `unenv/` polyfills:
 
 </details>
 
-## Manual mocking 
+## Manual mocking
 
 <details>
 

--- a/lib/index.d.mts
+++ b/lib/index.d.mts
@@ -8,16 +8,19 @@ export declare function defineEnv(opts?: CreateEnvOptions): {
 
 export interface CreateEnvOptions {
   /**
-   * Node.js compatibility aliases.
+   * Node.js compatibility.
+   *
+   * - Add `alias` entries for Node.js builtins as `<id>` and `node:<id>`.
+   * - Add `inject` entries for Node.js globals `global`, `Buffer`, and `process`.
    *
    * Default: `true`
    */
   nodeCompat?: boolean;
 
   /**
-   * NPM compatibility aliases.
+   * Add `alias` entries to replace npm packages like `node-fetch` with lighter shims.
    *
-   * Default: `true`
+   * Default: `false`
    */
   npmShims?: boolean;
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -61,7 +61,7 @@ function unenvPreset(opts: CreateEnvOptions) {
     });
   }
 
-  if (opts.npmShims !== false) {
+  if (opts.npmShims) {
     Object.assign(preset.alias, npmShims);
   }
 

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -69,19 +69,22 @@ export const nodeCompatAliases = {
   zlib: "unenv/node/zlib",
 } as const;
 
-export const npmShims = {
-  fsevents: "unenv/npm/fsevents",
-  "node-fetch": "unenv/npm/node-fetch",
-  "node-fetch-native": "unenv/npm/node-fetch",
-  "node-fetch-native/polyfill": "unenv/mock/empty",
-  "cross-fetch": "unenv/npm/cross-fetch",
-  "cross-fetch/polyfill": "unenv/mock/empty",
-  "isomorphic-fetch": "unenv/mock/empty",
-  inherits: "unenv/npm/inherits",
-} as const;
-
 export const nodeCompatInjects = {
   global: "unenv/polyfill/globalthis",
   process: "unenv/node/process",
   Buffer: ["unenv/node/buffer", "Buffer"],
+} as const;
+
+export const npmShims = {
+  "cross-fetch": "unenv/npm/cross-fetch",
+  debug: "unenv/npm/debug",
+  fsevents: "unenv/npm/fsevents",
+  inherits: "unenv/npm/inherits",
+  "node-fetch": "unenv/npm/node-fetch",
+  "node-fetch-native": "unenv/npm/node-fetch",
+  "whatwg-url": "unenv/npm/whatwg-url",
+  // polyfills
+  "cross-fetch/polyfill": "unenv/mock/empty",
+  "node-fetch-native/polyfill": "unenv/mock/empty",
+  "isomorphic-fetch": "unenv/mock/empty",
 } as const;


### PR DESCRIPTION
npm shims are an opinionated addon. This PR:

- Adds missing `debug`, `whatwg-url` shims to default preset
- Makes `npmShims` opt-in flag (not enabled by default)