### PR TITLE
refactor(process)!: extract nextTick to a separate file

### DIFF
--- a/src/runtime/node/internal/process/hrtime.ts
+++ b/src/runtime/node/internal/process/hrtime.ts
@@ -1,0 +1,29 @@
+// https://nodejs.org/api/process.html#processhrtime
+export const hrtime: NodeJS.Process["hrtime"] = Object.assign(
+  function hrtime(startTime?: [number, number] | undefined) {
+    const now = Date.now();
+    // millis to seconds
+    const seconds = Math.trunc(now / 1000);
+    // convert millis to nanos
+    const nanos = (now % 1000) * 1_000_000;
+
+    if (startTime) {
+      let diffSeconds = seconds - startTime[0];
+      let diffNanos = nanos - startTime[0];
+
+      if (diffNanos < 0) {
+        diffSeconds = diffSeconds - 1;
+        diffNanos = 1_000_000_000 + diffNanos;
+      }
+      return [diffSeconds, diffNanos] as [number, number];
+    }
+
+    return [seconds, nanos] as [number, number];
+  },
+  {
+    bigint: function bigint() {
+      // Convert milliseconds to nanoseconds
+      return BigInt(Date.now() * 1_000_000);
+    },
+  },
+);

--- a/src/runtime/node/internal/process/nexttick.ts
+++ b/src/runtime/node/internal/process/nexttick.ts
@@ -1,33 +1,3 @@
-// https://nodejs.org/api/process.html#processhrtime
-export const hrtime: NodeJS.Process["hrtime"] = Object.assign(
-  function hrtime(startTime?: [number, number] | undefined) {
-    const now = Date.now();
-    // millis to seconds
-    const seconds = Math.trunc(now / 1000);
-    // convert millis to nanos
-    const nanos = (now % 1000) * 1_000_000;
-
-    if (startTime) {
-      let diffSeconds = seconds - startTime[0];
-      let diffNanos = nanos - startTime[0];
-
-      if (diffNanos < 0) {
-        diffSeconds = diffSeconds - 1;
-        diffNanos = 1_000_000_000 + diffNanos;
-      }
-      return [diffSeconds, diffNanos] as [number, number];
-    }
-
-    return [seconds, nanos] as [number, number];
-  },
-  {
-    bigint: function bigint() {
-      // Convert milliseconds to nanoseconds
-      return BigInt(Date.now() * 1_000_000);
-    },
-  },
-);
-
 // https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask
 // https://nodejs.org/api/process.html#when-to-use-queuemicrotask-vs-processnexttick
 export const nextTick: NodeJS.Process["nextTick"] = globalThis.queueMicrotask

--- a/src/runtime/node/process.ts
+++ b/src/runtime/node/process.ts
@@ -1,10 +1,8 @@
 // https://nodejs.org/api/process.html
 import { Process } from "./internal/process/process.ts";
 import { env as UnenvEnv } from "./internal/process/env.ts";
-import {
-  hrtime as UnenvHrTime,
-  nextTick as UnenvNextTick,
-} from "./internal/process/time.ts";
+import { hrtime as UnenvHrTime } from "./internal/process/hrtime.ts";
+import { nextTick as UnenvNextTick } from "./internal/process/nexttick.ts";
 
 const unenvProcess = new Process({
   env: UnenvEnv,


### PR DESCRIPTION
This is needed so that cloudflare (i.e. any runtime with a `nextTick` impl) can drop the polyfill