### PR TITLE
refactor: improve `node:util` tree-shaking

### DIFF
--- a/src/runtime/node/internal/util/inherits.ts
+++ b/src/runtime/node/internal/util/inherits.ts
@@ -1,0 +1,14 @@
+export function inherits(ctor: any, superCtor: any) {
+  if (!superCtor) {
+    return;
+  }
+  ctor.super_ = superCtor;
+  ctor.prototype = Object.create(superCtor.prototype, {
+    constructor: {
+      value: ctor,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    },
+  });
+}

--- a/src/runtime/node/internal/util/promisify.ts
+++ b/src/runtime/node/internal/util/promisify.ts
@@ -25,7 +25,10 @@ function _promisify(fn: Fn & { [customSymbol]?: Fn }) {
   };
 }
 
-_promisify.custom = customSymbol;
-
 // @ts-ignore
-export const promisify: typeof util.promisify = _promisify;
+export const promisify: typeof util.promisify = /*@__PURE__*/ Object.assign(
+  _promisify,
+  {
+    custom: customSymbol,
+  },
+);

--- a/src/runtime/node/internal/util/promisify.ts
+++ b/src/runtime/node/internal/util/promisify.ts
@@ -1,6 +1,6 @@
 import type util from "node:util";
 
-const customSymbol = Symbol("customPromisify");
+const customSymbol = /*@__PURE__*/ Symbol("customPromisify");
 
 type Fn = (...args: any[]) => any;
 

--- a/src/runtime/node/util.ts
+++ b/src/runtime/node/util.ts
@@ -1,19 +1,23 @@
 // https://nodejs.org/api/util.html
 import type nodeUtil from "node:util";
+import types from "node:util/types";
 import { notImplemented } from "../_internal/utils.ts";
-import inherits from "../npm/inherits.ts";
+import { inherits } from "./internal/util/inherits.ts";
 import * as legacyTypes from "./internal/util/legacy-types.ts";
 import * as logUtils from "./internal/util/log.ts";
-import types from "node:util/types";
 import { promisify } from "./internal/util/promisify.ts";
 import * as mime from "./internal/util/mime.ts";
 
-export * from "./internal/util/mime.ts";
+export { MIMEParams, MIMEType } from "./internal/util/mime.ts";
+
 export * from "./internal/util/legacy-types.ts";
+
 export * from "./internal/util/log.ts";
 
-export { default as inherits } from "../npm/inherits.ts";
+export { inherits } from "./internal/util/inherits.ts";
+
 export { promisify } from "./internal/util/promisify.ts";
+
 export { default as types } from "node:util/types";
 
 // @ts-ignore
@@ -27,23 +31,30 @@ export const deprecate: typeof nodeUtil.deprecate = (fn) => fn;
 export const _errnoException = /*@__PURE__*/ notImplemented(
   "util._errnoException",
 );
+
 export const _exceptionWithHostPort = /*@__PURE__*/ notImplemented(
   "util._exceptionWithHostPort",
 );
+
 export const _extend = /*@__PURE__*/ notImplemented("util._extend");
 
 export const aborted =
   /*@__PURE__*/ notImplemented<typeof nodeUtil.aborted>("util.aborted");
+
 export const callbackify =
   /*@__PURE__*/ notImplemented<typeof nodeUtil.callbackify>("util.callbackify");
+
 export const getSystemErrorMap = /*@__PURE__*/ notImplemented<
   typeof nodeUtil.getSystemErrorMap
 >("util.getSystemErrorMap");
+
 export const getSystemErrorName = /*@__PURE__*/ notImplemented<
   typeof nodeUtil.getSystemErrorName
 >("util.getSystemErrorName");
+
 export const toUSVString =
   /*@__PURE__*/ notImplemented<typeof nodeUtil.toUSVString>("util.toUSVString");
+
 export const stripVTControlCharacters = /*@__PURE__*/ notImplemented<
   typeof nodeUtil.stripVTControlCharacters
 >("util.stripVTControlCharacters");
@@ -51,9 +62,11 @@ export const stripVTControlCharacters = /*@__PURE__*/ notImplemented<
 export const transferableAbortController = /*@__PURE__*/ notImplemented<
   typeof nodeUtil.transferableAbortController
 >("util.transferableAbortController");
+
 export const transferableAbortSignal = /*@__PURE__*/ notImplemented<
   typeof nodeUtil.transferableAbortSignal
 >("util.transferableAbortSignal");
+
 export const parseArgs =
   /*@__PURE__*/ notImplemented<typeof nodeUtil.parseArgs>("util.parseArgs");
 

--- a/src/runtime/npm/inherits.ts
+++ b/src/runtime/npm/inherits.ts
@@ -1,16 +1,3 @@
-// https://www.npmjs.com/package/inherits
-// Source: https://github.com/isaacs/inherits/blob/e6265134c91f9fb6a3d5e771f034ec94d20c6708/inherits_browser.js
-export default function inherits(ctor: any, superCtor: any) {
-  if (!superCtor) {
-    return;
-  }
-  ctor.super_ = superCtor;
-  ctor.prototype = Object.create(superCtor.prototype, {
-    constructor: {
-      value: ctor,
-      enumerable: false,
-      writable: true,
-      configurable: true,
-    },
-  });
-}
+import { inherits } from "node:util";
+
+export default inherits;


### PR DESCRIPTION
fixes related to #449

- general code readability 
- inherits is tree-shakable ([repl](https://esbuild.github.io/try/#YgAwLjI1LjAALS1idW5kbGUAZQBlbnRyeS50cwBpbXBvcnQgdHlwZSB1dGlsIGZyb20gIm5vZGU6dXRpbCI7Cgpjb25zdCBjdXN0b21TeW1ib2wgPSAvKkBfX1BVUkVfXyovIFN5bWJvbCgiY3VzdG9tUHJvbWlzaWZ5Iik7Cgp0eXBlIEZuID0gKC4uLmFyZ3M6IGFueVtdKSA9PiBhbnk7CgpmdW5jdGlvbiBfcHJvbWlzaWZ5KGZuOiBGbiAmIHsgW2N1c3RvbVN5bWJvbF0/OiBGbiB9KSB7CiAgaWYgKGZuW2N1c3RvbVN5bWJvbF0pIHsKICAgIHJldHVybiBmbltjdXN0b21TeW1ib2xdOwogIH0KICByZXR1cm4gZnVuY3Rpb24gKC4uLmFyZ3M6IGFueVtdKSB7CiAgICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4gewogICAgICB0cnkgewogICAgICAgIC8vIEB0cy1pZ25vcmUKICAgICAgICBmbi5jYWxsKHRoaXMsIC4uLmFyZ3MsIChlcnIsIHZhbCkgPT4gewogICAgICAgICAgaWYgKGVycikgewogICAgICAgICAgICByZXR1cm4gcmVqZWN0KGVycik7CiAgICAgICAgICB9CiAgICAgICAgICByZXNvbHZlKHZhbCk7CiAgICAgICAgfSk7CiAgICAgIH0gY2F0Y2ggKGVycm9yKSB7CiAgICAgICAgcmVqZWN0KGVycm9yKTsKICAgICAgfQogICAgfSk7CiAgfTsKfQoKLy8gQHRzLWlnbm9yZQpjb25zdCBwcm9taXNpZnk6IHR5cGVvZiB1dGlsLnByb21pc2lmeSA9IC8qQF9fUFVSRV9fKi8gT2JqZWN0LmFzc2lnbigKICBfcHJvbWlzaWZ5LAogIHsKICAgIGN1c3RvbTogY3VzdG9tU3ltYm9sLAogIH0sCik7Cg))
- `unenv/npm/inherits` shim uses `node:util` as source

/cc @vicb 