### PR TITLE
fix: circular dependency between node and web `performance.now()`

### DIFF
--- a/src/runtime/node/internal/perf_hooks/performance.ts
+++ b/src/runtime/node/internal/perf_hooks/performance.ts
@@ -32,16 +32,14 @@ const nodeTiming = {
   uvMetricsInfo: { loopCount: 0, events: 0, eventsWaiting: 0 },
   // only present in Node.js 18.x
   detail: undefined,
-} satisfies Omit<nodePerfHooks.PerformanceNodeTiming, "toJSON">;
+  toJSON: () => this,
+} satisfies nodePerfHooks.PerformanceNodeTiming;
 
 // Performance
 export const Performance = class Performance
   extends _Performance<nodePerfHooks.PerformanceEntry>
   implements nodePerfHooks.Performance
 {
-  constructor() {
-    super();
-  }
   timerify<T extends (...params: any[]) => any>(
     _fn: T,
     _options?: nodePerfHooks.TimerifyOptions | undefined,
@@ -50,10 +48,7 @@ export const Performance = class Performance
   }
 
   get nodeTiming(): nodePerfHooks.PerformanceNodeTiming {
-    return {
-      ...nodeTiming,
-      toJSON: () => nodeTiming,
-    };
+    return nodeTiming;
   }
 
   eventLoopUtilization() {

--- a/src/runtime/polyfill/performance.ts
+++ b/src/runtime/polyfill/performance.ts
@@ -9,17 +9,13 @@ import {
   PerformanceResourceTiming,
 } from "../web/performance/index.ts";
 
-globalThis.performance = globalThis.performance || performance;
-globalThis.Performance = globalThis.Performance || Performance;
-globalThis.PerformanceEntry = globalThis.PerformanceEntry || PerformanceEntry;
-globalThis.PerformanceMark = globalThis.PerformanceMark || PerformanceMark;
-globalThis.PerformanceMeasure =
-  globalThis.PerformanceMeasure || PerformanceMeasure;
-globalThis.PerformanceObserver =
-  globalThis.PerformanceObserver || PerformanceObserver;
-globalThis.PerformanceObserverEntryList =
-  globalThis.PerformanceObserverEntryList || PerformanceObserverEntryList;
-globalThis.PerformanceResourceTiming =
-  globalThis.PerformanceResourceTiming || PerformanceResourceTiming;
+globalThis.performance ||= performance;
+globalThis.Performance ||= Performance;
+globalThis.PerformanceEntry ||= PerformanceEntry;
+globalThis.PerformanceMark ||= PerformanceMark;
+globalThis.PerformanceMeasure ||= PerformanceMeasure;
+globalThis.PerformanceObserver ||= PerformanceObserver;
+globalThis.PerformanceObserverEntryList ||= PerformanceObserverEntryList;
+globalThis.PerformanceResourceTiming ||= PerformanceResourceTiming;
 
 export default globalThis.performance;

--- a/src/runtime/web/performance/_performance.ts
+++ b/src/runtime/web/performance/_performance.ts
@@ -93,11 +93,9 @@ export class _Performance<
       end = this.getEntriesByName(endMark!, "mark")[0]?.startTime;
     } else {
       start =
-        Number.parseFloat(startOrMeasureOptions?.start as string) ||
-        performance.now();
+        Number.parseFloat(startOrMeasureOptions?.start as string) || this.now();
       end =
-        Number.parseFloat(startOrMeasureOptions?.end as string) ||
-        performance.now();
+        Number.parseFloat(startOrMeasureOptions?.end as string) || this.now();
     }
     const entry = new _PerformanceMeasure(measureName, {
       startTime: start,


### PR DESCRIPTION
@pi0 That should be enough for us to fix our "performance issue".

It would be nice to remove the circular dep `Performance` -> `perfomance` (`Perfomance#now` & `performance = new Performance`) but it is not a problem for us at this point.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #463 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #461 
<!-- GitButler Footer Boundary Bottom -->

