### PR TITLE
feat: update node compat injects

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -70,9 +70,11 @@ export const nodeCompatAliases = {
 } as const;
 
 export const nodeCompatInjects = {
-  global: "unenv/polyfill/globalthis",
   process: "unenv/node/process",
-  Buffer: ["unenv/node/buffer", "Buffer"],
+  global: "unenv/polyfill/globalthis",
+  Buffer: ["node:buffer", "Buffer"],
+  clearImmediate: ["node:timers", "clearImmediate"],
+  setImmediate: ["node:timers", "setImmediate"],
 } as const;
 
 export const npmShims = {

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -42,10 +42,12 @@ describe("defineEnv", () => {
         expect(existsSync(path), path).toBe(true);
       }
       for (const inject of Object.values(env.inject)) {
-        expect(
-          existsSync(Array.isArray(inject) ? inject[0] : inject),
-          inject.toString(),
-        ).toBe(true);
+        const to = Array.isArray(inject) ? inject[0] : inject;
+        // TODO: Resolve with aliases
+        if (to.startsWith("node:")) {
+          continue;
+        }
+        expect(existsSync(to), inject.toString()).toBe(true);
       }
     });
   });


### PR DESCRIPTION
This PR improves node compat injects preset:

- Use `node:buffer` for `Buffer` inject (this way native aliases are considered) 
- Add `setImmediate` and `clearImmediate` from `node:timers`

Note: Test updated as currently `resolve: true` does not respects aliases fixing in next one!

/cc @vicb 