### PR TITLE
fix(defineEnv): resolve paths with aliases

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,5 @@
 import { resolvePathSync, type ResolveOptions } from "mlly";
+import { resolveAlias } from "pathe/utils";
 import type {
   Preset,
   Environment,
@@ -104,6 +105,7 @@ function resolveEnvPaths(
     if (!id) {
       return id;
     }
+    id = resolveAlias(id, env.alias);
     let resolved = _tryResolve(id);
     if (!resolved && id.startsWith("unenv/")) {
       resolved = _tryResolve(id.replace("unenv/", "unenv-nightly/"));

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -33,9 +33,6 @@ describe("defineEnv", () => {
     it("resolves all nodeCompat paths", () => {
       const { env } = defineEnv({ nodeCompat: true, resolve: true });
       for (const [from, to] of Object.entries(env.alias)) {
-        if (to.startsWith("node:")) {
-          continue; // recursive
-        }
         expect(existsSync(to), `Alias: ${from} ~> ${to}`).toBe(true);
       }
       for (const path of env.polyfill) {
@@ -43,10 +40,6 @@ describe("defineEnv", () => {
       }
       for (const inject of Object.values(env.inject)) {
         const to = Array.isArray(inject) ? inject[0] : inject;
-        // TODO: Resolve with aliases
-        if (to.startsWith("node:")) {
-          continue;
-        }
         expect(existsSync(to), inject.toString()).toBe(true);
       }
     });


### PR DESCRIPTION
found from #465

This fixes the issue where `defineEnv({ resolve: true })` is not respecing aliases. Final result sometimes have raw `node:` specifiers even though aliases configured to unenv absolute paths.