### PR TITLE
feat(defineEnv): support disabling `polyfill` and `external` with `!` prefix

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -184,8 +184,23 @@ function mergePresets(...presets: Preset[]): ResolvedEnvironment {
     }
   }
 
-  env.polyfill = [...new Set(env.polyfill)];
-  env.external = [...new Set(env.external)];
+  env.polyfill = resolveArray(env.polyfill);
+  env.external = resolveArray(env.external);
 
   return env;
+}
+
+/**
+ * - Deduplicates items
+ * - Removes nagate items with ! prefix
+ */
+function resolveArray(arr: string[]) {
+  const set = new Set<string>(arr);
+  for (const item of arr) {
+    if (item.startsWith("!")) {
+      set.delete(item);
+      set.delete(item.slice(1));
+    }
+  }
+  return [...set];
 }

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -29,6 +29,18 @@ describe("defineEnv", () => {
     }
   });
 
+  it("nagate", () => {
+    const { env } = defineEnv({
+      nodeCompat: false,
+      overrides: {
+        polyfill: ["foo", "bar", "!foo"],
+        external: ["foo", "bar", "!foo"],
+      },
+    });
+    expect(env.polyfill).toEqual(["bar"]);
+    expect(env.external).toEqual(["bar"]);
+  });
+
   describe("resolvePath", () => {
     it("resolves all nodeCompat paths", () => {
       const { env } = defineEnv({ nodeCompat: true, resolve: true });


### PR DESCRIPTION
It is possible to disable alias and injects by overriding their values with `false`

However it is is not possible to disable items from `polyfil` and `external` arrays.

This PR allows using `!<id>` to disable them via preset overrides.