### PR TITLE
refactor: prefer `node:*/promises` for `promises` export

### DIFF
--- a/src/runtime/node/inspector/promises.ts
+++ b/src/runtime/node/inspector/promises.ts
@@ -1,40 +1,61 @@
-import type inspectorPromises from "node:inspector/promises";
+import type nodeInspectorPromises from "node:inspector/promises";
 import { notImplemented, notImplementedClass } from "../../_internal/utils.ts";
+import noop from "../../mock/noop.ts";
 
-import { console as inspectorConsole } from "../inspector.ts";
-
-export { console } from "../inspector.ts";
+export const console: typeof nodeInspectorPromises.console = {
+  debug: noop,
+  error: noop,
+  info: noop,
+  log: noop,
+  warn: noop,
+  dir: noop,
+  dirxml: noop,
+  table: noop,
+  trace: noop,
+  group: noop,
+  groupCollapsed: noop,
+  groupEnd: noop,
+  clear: noop,
+  count: noop,
+  countReset: noop,
+  assert: noop,
+  profile: noop,
+  profileEnd: noop,
+  time: noop,
+  timeLog: noop,
+  timeStamp: noop,
+};
 
 export const Network = /*@__PURE__*/ notImplementedClass<
-  typeof inspectorPromises.Network
->("inspectorPromises.Network");
+  typeof nodeInspectorPromises.Network
+>("nodeInspectorPromises.Network");
 
 export const Session = /*@__PURE__*/ notImplementedClass<
-  typeof inspectorPromises.Session
->("inspectorPromises.Session");
+  typeof nodeInspectorPromises.Session
+>("nodeInspectorPromises.Session");
 
-export const url = /*@__PURE__*/ notImplemented<typeof inspectorPromises.url>(
-  "inspectorPromises.url",
-);
+export const url = /*@__PURE__*/ notImplemented<
+  typeof nodeInspectorPromises.url
+>("nodeInspectorPromises.url");
 
 export const waitForDebugger = /*@__PURE__*/ notImplemented<
-  typeof inspectorPromises.waitForDebugger
->("inspectorPromises.waitForDebugger");
+  typeof nodeInspectorPromises.waitForDebugger
+>("nodeInspectorPromises.waitForDebugger");
 
-export const open = /*@__PURE__*/ notImplemented<typeof inspectorPromises.open>(
-  "inspectorPromises.open",
-);
+export const open = /*@__PURE__*/ notImplemented<
+  typeof nodeInspectorPromises.open
+>("nodeInspectorPromises.open");
 
 export const close = /*@__PURE__*/ notImplemented<
-  typeof inspectorPromises.close
->("inspectorPromises.close");
+  typeof nodeInspectorPromises.close
+>("nodeInspectorPromises.close");
 
 export default {
   close,
-  console: inspectorConsole,
+  console,
   Network,
   open,
   Session,
   url,
   waitForDebugger,
-} satisfies typeof inspectorPromises;
+} satisfies typeof nodeInspectorPromises;

--- a/src/runtime/node/inspector/promises.ts
+++ b/src/runtime/node/inspector/promises.ts
@@ -28,27 +28,27 @@ export const console: typeof nodeInspectorPromises.console = {
 
 export const Network = /*@__PURE__*/ notImplementedClass<
   typeof nodeInspectorPromises.Network
->("nodeInspectorPromises.Network");
+>("inspectorPromises.Network");
 
 export const Session = /*@__PURE__*/ notImplementedClass<
   typeof nodeInspectorPromises.Session
->("nodeInspectorPromises.Session");
+>("inspectorPromises.Session");
 
 export const url = /*@__PURE__*/ notImplemented<
   typeof nodeInspectorPromises.url
->("nodeInspectorPromises.url");
+>("inspectorPromises.url");
 
 export const waitForDebugger = /*@__PURE__*/ notImplemented<
   typeof nodeInspectorPromises.waitForDebugger
->("nodeInspectorPromises.waitForDebugger");
+>("inspectorPromises.waitForDebugger");
 
 export const open = /*@__PURE__*/ notImplemented<
   typeof nodeInspectorPromises.open
->("nodeInspectorPromises.open");
+>("inspectorPromises.open");
 
 export const close = /*@__PURE__*/ notImplemented<
   typeof nodeInspectorPromises.close
->("nodeInspectorPromises.close");
+>("inspectorPromises.close");
 
 export default {
   close,

--- a/src/runtime/node/readline.ts
+++ b/src/runtime/node/readline.ts
@@ -1,10 +1,11 @@
 // https://nodejs.org/api/readline.html#readlineclearlinestream-dir-callback
 import type nodeReadline from "node:readline";
 import noop from "../mock/noop.ts";
-import promises from "./readline/promises.ts";
+import promises from "node:readline";
 import { Interface } from "./internal/readline/interface.ts";
 
-export * as promises from "./readline/promises.ts";
+export { promises };
+
 export { Interface } from "./internal/readline/interface.ts";
 
 export const clearLine: typeof nodeReadline.clearLine = () => false;
@@ -16,12 +17,14 @@ export const emitKeypressEvents: typeof nodeReadline.emitKeypressEvents = noop;
 export const moveCursor: typeof nodeReadline.moveCursor = () => false;
 
 export default {
-  Interface,
   clearLine,
   clearScreenDown,
   createInterface,
   cursorTo,
   emitKeypressEvents,
   moveCursor,
+  // @ts-expect-error
+  Interface,
+  // @ts-expect-error
   promises,
-} as /* TODO: use satisfies */ typeof nodeReadline;
+} satisfies typeof nodeReadline;

--- a/src/runtime/node/stream.ts
+++ b/src/runtime/node/stream.ts
@@ -6,9 +6,9 @@ import { Writable } from "./internal/stream/writable.ts";
 import { Duplex } from "./internal/stream/duplex.ts";
 import { Transform } from "./internal/stream/transform.ts";
 
-import promises from "./stream/promises.ts";
+import promises from "node:stream/promises";
 
-export { default as promises } from "./stream/promises.ts";
+export { promises };
 
 export { Readable } from "./internal/stream/readable.ts";
 export { Writable } from "./internal/stream/writable.ts";

--- a/src/runtime/node/timers.ts
+++ b/src/runtime/node/timers.ts
@@ -1,7 +1,7 @@
 import { notImplemented } from "../_internal/utils.ts";
 import noop from "../mock/noop.ts";
 import type nodeTimers from "node:timers";
-import promises from "./timers/promises.ts";
+import promises from "node:timers/promises";
 import { setTimeoutFallback } from "./internal/timers/set-timeout.ts";
 import {
   setImmediateFallback,
@@ -9,7 +9,7 @@ import {
 } from "./internal/timers/set-immediate.ts";
 import { setIntervalFallback } from "./internal/timers/set-interval.ts";
 
-export * as promises from "./timers/promises.ts";
+export { promises };
 
 export const clearImmediate: typeof nodeTimers.clearImmediate =
   globalThis.clearImmediate?.bind(globalThis) || clearImmediateFallback;


### PR DESCRIPTION
Leftover follow-up from #460

This PR changes `promises` export from `node:<id>` modules to use `node:<id>/promises` default export instead of using local paths which increases ability to implement hybrid by only implementing `/promises` variant.

Updated `inspector/promises.ts` to remove circular dep issue.

/cc @vicb can you please check specially for `node:timers/promises` if won't make any potential trouble for you?