### PR TITLE
refactor: mark all symbol inits as pure to allow treeshake

### DIFF
--- a/src/runtime/node/http2.ts
+++ b/src/runtime/node/http2.ts
@@ -52,9 +52,8 @@ export const getUnpackedSettings: typeof nodeHttp2.getUnpackedSettings =
     return Object.create({});
   };
 
-export const sensitiveHeaders: typeof nodeHttp2.sensitiveHeaders = Symbol(
-  "nodejs.http2.sensitiveHeaders",
-);
+export const sensitiveHeaders: typeof nodeHttp2.sensitiveHeaders =
+  /*@__PURE__*/ Symbol("nodejs.http2.sensitiveHeaders");
 
 export default {
   constants,

--- a/src/runtime/node/internal/async_hooks/async-hook.ts
+++ b/src/runtime/node/internal/async_hooks/async-hook.ts
@@ -4,6 +4,12 @@ import type nodeAsyncHooks from "node:async_hooks";
 
 type NodeAsyncHook = ReturnType<typeof nodeAsyncHooks.createHook>;
 
+const kInit = /*@__PURE__*/ Symbol("init");
+const kBefore = /*@__PURE__*/ Symbol("before");
+const kAfter = /*@__PURE__*/ Symbol("after");
+const kDestroy = /*@__PURE__*/ Symbol("destroy");
+const kPromiseResolve = /*@__PURE__*/ Symbol("promiseResolve");
+
 class _AsyncHook implements NodeAsyncHook {
   readonly __unenv__ = true;
 
@@ -24,23 +30,23 @@ class _AsyncHook implements NodeAsyncHook {
     return this;
   }
 
-  get [Symbol("init")]() {
+  get [kInit]() {
     return this._callbacks.init;
   }
 
-  get [Symbol("before")]() {
+  get [kBefore]() {
     return this._callbacks.before;
   }
 
-  get [Symbol("after")]() {
+  get [kAfter]() {
     return this._callbacks.after;
   }
 
-  get [Symbol("destroy")]() {
+  get [kDestroy]() {
     return this._callbacks.destroy;
   }
 
-  get [Symbol("promiseResolve")]() {
+  get [kPromiseResolve]() {
     return this._callbacks.promiseResolve;
   }
 }

--- a/src/runtime/node/internal/events/events.ts
+++ b/src/runtime/node/internal/events/events.ts
@@ -46,18 +46,24 @@ const AbortError = Error;
 const genericNodeError = Error;
 
 // Symbols
-const kRejection = Symbol.for("nodejs.rejection");
-const kCapture = Symbol.for("kCapture");
-const kErrorMonitor = Symbol.for("events.errorMonitor");
-const kShapeMode = Symbol.for("shapeMode");
-const kMaxEventTargetListeners = Symbol.for("events.maxEventTargetListeners");
-const kEnhanceStackBeforeInspector = Symbol.for("kEnhanceStackBeforeInspector");
-const kWatermarkData = Symbol.for("nodejs.watermarkData");
-const kEventEmitter = Symbol.for("kEventEmitter");
-const kAsyncResource = Symbol.for("kAsyncResource");
-const kFirstEventParam = Symbol.for("kFirstEventParam");
-const kResistStopPropagation = Symbol.for("kResistStopPropagation");
-const kMaxEventTargetListenersWarned = Symbol.for(
+const kRejection = /*@__PURE__*/ Symbol.for("nodejs.rejection");
+const kCapture = /*@__PURE__*/ Symbol.for("kCapture");
+const kErrorMonitor = /*@__PURE__*/ Symbol.for("events.errorMonitor");
+const kShapeMode = /*@__PURE__*/ Symbol.for("shapeMode");
+const kMaxEventTargetListeners = /*@__PURE__*/ Symbol.for(
+  "events.maxEventTargetListeners",
+);
+const kEnhanceStackBeforeInspector = /*@__PURE__*/ Symbol.for(
+  "kEnhanceStackBeforeInspector",
+);
+const kWatermarkData = /*@__PURE__*/ Symbol.for("nodejs.watermarkData");
+const kEventEmitter = /*@__PURE__*/ Symbol.for("kEventEmitter");
+const kAsyncResource = /*@__PURE__*/ Symbol.for("kAsyncResource");
+const kFirstEventParam = /*@__PURE__*/ Symbol.for("kFirstEventParam");
+const kResistStopPropagation = /*@__PURE__*/ Symbol.for(
+  "kResistStopPropagation",
+);
+const kMaxEventTargetListenersWarned = /*@__PURE__*/ Symbol.for(
   "events.maxEventTargetListenersWarned",
 );
 

--- a/src/runtime/node/vm.ts
+++ b/src/runtime/node/vm.ts
@@ -10,7 +10,7 @@ export * as constants from "./internal/vm/constants.ts";
 export const compileFunction: typeof nodeVm.compileFunction =
   /*@__PURE__*/ notImplemented("vm.compileFunction");
 
-const _contextSymbol = Symbol("uenv.vm.context");
+const _contextSymbol = /*@__PURE__*/ Symbol("uenv.vm.context");
 
 export const createContext: typeof nodeVm.createContext =
   function createContext() {

--- a/src/runtime/node/worker_threads.ts
+++ b/src/runtime/node/worker_threads.ts
@@ -42,7 +42,7 @@ export const parentPort: typeof nodeWorkerThreads.parentPort = null;
 export const receiveMessageOnPort: typeof nodeWorkerThreads.receiveMessageOnPort =
   () => undefined;
 
-export const SHARE_ENV = Symbol.for(
+export const SHARE_ENV = /*@__PURE__*/ Symbol.for(
   "nodejs.worker_threads.SHARE_ENV",
 ) as typeof nodeWorkerThreads.SHARE_ENV;
 


### PR DESCRIPTION
Some leftover symbols not marked as pure (which cases esbuild to not treeshake any usage of them)