### PR TITLE
fix(process): add `getOwnPropertyDescriptor` for `process.env`

### DIFF
--- a/src/runtime/node/internal/process/env.ts
+++ b/src/runtime/node/internal/process/env.ts
@@ -1,9 +1,8 @@
 const _envShim = Object.create(null);
-const _processEnv = globalThis.process?.env;
 
 const _getEnv = (useShim?: boolean) =>
-  _processEnv ||
   (globalThis as any).__env__ ||
+  globalThis["process"]?.env ||
   (useShim ? _envShim : globalThis);
 
 export const env: NodeJS.Process["env"] = /*@__PURE__*/ new Proxy(_envShim, {
@@ -28,5 +27,17 @@ export const env: NodeJS.Process["env"] = /*@__PURE__*/ new Proxy(_envShim, {
   ownKeys() {
     const env = _getEnv();
     return Object.keys(env);
+  },
+  getOwnPropertyDescriptor(_, prop) {
+    const env = _getEnv();
+    if (prop in env) {
+      return {
+        value: env[prop as string],
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      };
+    }
+    return undefined;
   },
 });

--- a/test/node-env.test.ts
+++ b/test/node-env.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { env } from "../src/runtime/node/internal/process/env";
+
+describe("process.env polyfill", () => {
+  it("env.TEST", () => {
+    expect(env.TEST).toBe("true");
+  });
+
+  it("env.CUSTOM", () => {
+    env.CUSTOM = "true";
+    expect(env.CUSTOM).toBe("true");
+  });
+
+  it("Object.keys(env)", () => {
+    expect(Object.keys(env)).toContain("TEST");
+    expect(Object.keys(env)).toContain("CUSTOM");
+  });
+
+  it("Object.entries(env)", () => {
+    expect(Object.entries(env)).toContainEqual(["TEST", "true"]);
+  });
+});


### PR DESCRIPTION
Logging `process.env` polyfill was always leading to `{}` (while `process.env.TEST` worked) this PR makes debugging and `Object.keys`/`Object.entries` work.

This PR also fixes order to respect `globalThis.__env__` if set