### PR TITLE
fix: validate `globalThis.performance` before reexporting it

### DIFF
--- a/src/runtime/node/internal/perf_hooks/performance.ts
+++ b/src/runtime/node/internal/perf_hooks/performance.ts
@@ -337,5 +337,10 @@ export class PerformanceObserver implements nodePerfHooks.PerformanceObserver {
   }
 }
 
-export const performance = (globalThis.performance ??
-  new Performance()) as unknown as nodePerfHooks.Performance;
+// workerd implements a subset of globalThis.performance (as of last check, only timeOrigin set to 0 + now() implemented)
+// We already use performance.now() from globalThis.performance, if provided (see top of this file)
+// If we detect this condition, we can just use polyfill instead.
+export const performance =
+  globalThis.performance && "addEventListener" in globalThis.performance
+    ? globalThis.performance
+    : (new Performance() as unknown as nodePerfHooks.Performance);

--- a/src/runtime/node/internal/perf_hooks/performance.ts
+++ b/src/runtime/node/internal/perf_hooks/performance.ts
@@ -2,7 +2,7 @@ import type nodePerfHooks from "node:perf_hooks";
 
 import { createNotImplementedError } from "../../../_internal/utils.ts";
 
-const _timeOrigin = Date.now();
+const _timeOrigin = globalThis.performance?.timeOrigin ?? Date.now();
 
 const _performanceNow = globalThis.performance?.now
   ? globalThis.performance.now.bind(globalThis.performance)

--- a/src/runtime/node/perf_hooks.ts
+++ b/src/runtime/node/perf_hooks.ts
@@ -52,8 +52,9 @@ export default {
   PerformanceObserver,
   // @ts-expect-error TODO: resolve type-mismatch between web and node
   PerformanceResourceTiming,
+  // @ts-expect-error TODO: resolve type-mismatch between web and node
+  performance,
   constants,
   createHistogram,
   monitorEventLoopDelay,
-  performance,
 } satisfies Omit<typeof nodePerfHooks, "PerformanceNodeTiming">; // @types/node bug: PerformanceNodeTiming is included in the types but doesn't exist in the runtime

--- a/src/runtime/web/performance/_polyfills.ts
+++ b/src/runtime/web/performance/_polyfills.ts
@@ -2,7 +2,7 @@ import { createNotImplementedError } from "../../_internal/utils.ts";
 
 export type _PerformanceEntryType = "mark" | "measure" | "resource" | "event";
 
-const _timeOrigin = Date.now();
+const _timeOrigin = globalThis.performance?.timeOrigin ?? Date.now();
 
 const _performanceNow = globalThis.performance?.now
   ? globalThis.performance.now.bind(globalThis.performance)

--- a/src/runtime/web/performance/index.ts
+++ b/src/runtime/web/performance/index.ts
@@ -43,5 +43,10 @@ export const Performance: typeof globalThis.Performance =
 export const PerformanceObserverEntryList: typeof globalThis.PerformanceObserverEntryList =
   globalThis.PerformanceObserverEntryList || _PerformanceObserverEntryList;
 
-export const performance: typeof globalThis.performance =
-  globalThis.performance || new _Performance();
+// workerd implements a subset of globalThis.performance (as of last check, only timeOrigin set to 0 + now() implemented)
+// We already use performance.now() from globalThis.performance, if provided (see top of this file)
+// If we detect this condition, we can just use polyfill instead.
+export const performance =
+  globalThis.performance && "addEventListener" in globalThis.performance
+    ? globalThis.performance
+    : new _Performance();


### PR DESCRIPTION
Followup #478

workerd runtime, provides `globalThis.performance` but only `timeOrigin: 0` + `now()` (which we anyway always pick and use also in polyfill.

/cc @vicb wondering after this two PRs, do we even need a hybrid entry on cloudflare preset?