### PR TITLE
refactor(node:events): simple top level exports

### DIFF
--- a/src/runtime/node/events.ts
+++ b/src/runtime/node/events.ts
@@ -2,6 +2,7 @@
 import type nodeEvents from "node:events";
 
 import { _EventEmitter } from "./internal/events/events.ts";
+import { notImplemented } from "../_internal/utils.ts";
 
 export {
   _EventEmitter as EventEmitter,
@@ -13,13 +14,25 @@ export {
   once,
 } from "./internal/events/events.ts";
 
-export const usingDomains = _EventEmitter.usingDomains;
-export const captureRejectionSymbol = _EventEmitter.captureRejectionSymbol;
-export const captureRejections = false; // Coverage only
-export const errorMonitor = _EventEmitter.errorMonitor;
-export const defaultMaxListeners = _EventEmitter.defaultMaxListeners;
-export const setMaxListeners = _EventEmitter.setMaxListeners;
-export const listenerCount = _EventEmitter.listenerCount;
-export const init = _EventEmitter.init;
+export const usingDomains = false;
+
+export const captureRejectionSymbol =
+  /*@__PURE__*/ Symbol.for("nodejs.rejection");
+
+export const captureRejections = false;
+
+export const errorMonitor = /*@__PURE__*/ Symbol.for("events.errorMonitor");
+
+export const defaultMaxListeners = 10;
+
+export const setMaxListeners = /*@__PURE__*/ notImplemented(
+  "node:events.setMaxListeners",
+);
+
+export const listenerCount = /*@__PURE__*/ notImplemented(
+  "node:events.listenerCount",
+);
+
+export const init = /*@__PURE__*/ notImplemented("node:events.init");
 
 export default _EventEmitter as typeof nodeEvents;

--- a/src/runtime/node/internal/events/events.ts
+++ b/src/runtime/node/internal/events/events.ts
@@ -89,7 +89,7 @@ export class _EventEmitter implements NodeEventEmitter {
   static kMaxEventTargetListenersWarned = kMaxEventTargetListenersWarned;
 
   // Static utils
-  static usingDomains = false; // backwards compatibilit
+  static usingDomains = false; // backwards compat
   static get on() {
     return on;
   }


### PR DESCRIPTION
Top level exports unenv has for `node:events` are mainly for coverage purposes. Some, like `node:events.listenerCount` fail on Node.js itself.

```
> events.listenerCount()
Uncaught TypeError: Cannot read properties of undefined (reading 'listenerCount')
    at Function.listenerCount (node:events:835:22)
```

This PR makes side-effect free and remove dependency loops.