### PR TITLE
fix(node:process): return undefined for `getBuiltinModule`

### DIFF
--- a/src/runtime/node/internal/process/process.ts
+++ b/src/runtime/node/internal/process/process.ts
@@ -172,7 +172,7 @@ export class Process extends EventEmitter implements NodeJS.Process {
   }
 
   getBuiltinModule(): any {
-    throw createNotImplementedError("process.getBuiltinModule");
+    return undefined;
   }
 
   getActiveResourcesInfo(): string[] {


### PR DESCRIPTION
https://github.com/nuxt/nuxt/issues/31290

`process.getBuiltinModule` in Node.js returns undefined for unsupported modules. 

This PR makes mock backward compatible with unenv v1.