### PR TITLE
refactor(node:tty): standalone implementations

### DIFF
--- a/src/runtime/node/internal/tty/read-stream.ts
+++ b/src/runtime/node/internal/tty/read-stream.ts
@@ -1,16 +1,17 @@
 import type nodeTty from "node:tty";
 import { Socket } from "node:net";
 
-export class ReadStream extends Socket implements nodeTty.ReadStream {
+export class ReadStream implements Partial<nodeTty.ReadStream> {
   fd: number;
+  isRaw = false;
+  isTTY = false;
+
   constructor(fd: number) {
-    super();
     this.fd = fd;
   }
-  isRaw = false;
+
   setRawMode(mode: boolean) {
     this.isRaw = mode;
-    return this;
+    return this as unknown as nodeTty.ReadStream;
   }
-  isTTY = false;
 }

--- a/src/runtime/node/internal/tty/write-stream.ts
+++ b/src/runtime/node/internal/tty/write-stream.ts
@@ -1,20 +1,25 @@
 import type nodeTty from "node:tty";
-import { Socket } from "node:net";
 
-export class WriteStream extends Socket implements nodeTty.WriteStream {
+export class WriteStream implements Partial<nodeTty.WriteStream> {
   fd: number;
+  columns = 80;
+  rows = 24;
+  isTTY = false;
+
   constructor(fd: number) {
-    super();
     this.fd = fd;
   }
+
   clearLine(dir: nodeTty.Direction, callback?: (() => void) | undefined) {
     callback && callback();
     return false;
   }
+
   clearScreenDown(callback?: (() => void) | undefined) {
     callback && callback();
     return false;
   }
+
   cursorTo(
     x: number,
     y?: number | undefined,
@@ -25,23 +30,41 @@ export class WriteStream extends Socket implements nodeTty.WriteStream {
     callback && typeof callback === "function" && callback();
     return false;
   }
+
   moveCursor(dx: number, dy: number, callback?: (() => void) | undefined) {
     callback && callback();
     return false;
   }
+
   getColorDepth(env?: object | undefined): number {
     return 1;
   }
+
   hasColors(count?: number | undefined): boolean;
   hasColors(env?: object | undefined): boolean;
   hasColors(count: number, env?: object | undefined): boolean;
   hasColors(count?: unknown, env?: unknown): boolean {
     return false;
   }
+
   getWindowSize(): [number, number] {
     return [this.columns, this.rows];
   }
-  columns = 80;
-  rows = 24;
-  isTTY = false;
+
+  write(buffer: Uint8Array | string, cb?: (err?: Error) => void): boolean;
+  write(
+    str: Uint8Array | string,
+    encoding?: BufferEncoding,
+    cb?: (err?: Error) => void,
+  ): boolean;
+  write(str: unknown, encoding?: unknown, cb?: unknown): boolean {
+    if (str instanceof Uint8Array) {
+      str = new TextDecoder().decode(str);
+    }
+    try {
+      console.log(str);
+    } catch {}
+    cb && typeof cb === "function" && cb();
+    return false;
+  }
 }

--- a/src/runtime/node/tty.ts
+++ b/src/runtime/node/tty.ts
@@ -10,7 +10,7 @@ export const isatty: typeof nodeTty.isatty = function () {
 };
 
 export default {
-  ReadStream,
-  WriteStream,
+  ReadStream: WriteStream as unknown as typeof nodeTty.ReadStream,
+  WriteStream: WriteStream as unknown as typeof nodeTty.WriteStream,
   isatty,
 } satisfies typeof nodeTty;


### PR DESCRIPTION
(context: found while investigating https://github.com/nuxt-hub/core/issues/499)

Current `ReadStream`/`WriteStream` polyfill implementations used for `process.std{in,out,err}` polyfills are extending `node:net` wrongly.

This causes not only extra bundle impact when not used (in pure polyfill mode) but also is the wrong extension as `tty` is not a network socket and also internal cycling dependencies.

Also `process.std{out,err}.write` was completely nonfunctional.

I have implemented both as partial types with `WriteStream.write` redirect to real `console` as polyfill.

I don't expect any libraries in compat mode to expect more tty methods but we can later explicitly implement/mock them if needed. Alternatively, overlay presets can check implementation.