### PR TITLE
fix: avoid circular dependency between `process` and `node:events`

### DIFF
--- a/src/runtime/node/internal/events/events.ts
+++ b/src/runtime/node/internal/events/events.ts
@@ -1110,7 +1110,9 @@ function addCatch(
       then.call(promise, undefined, function (err: Error) {
         // The callback is called with nextTick to avoid a follow-up
         // rejection from this promise.
-        process.nextTick(emitUnhandledRejectionOrErr, that, err, type, args);
+        // Avoid using process. from events to avoid circular dependency
+        // process.nextTick(emitUnhandledRejectionOrErr, that, err, type, args);
+        setTimeout(emitUnhandledRejectionOrErr, 0, that, err, type, args);
       });
     }
   } catch (error_) {
@@ -1241,7 +1243,8 @@ function _addListener(
           count: existing.length,
         },
       );
-      process.emitWarning(w);
+      // Avoid using process from events to avoid circular dependency
+      console.warn(w);
     }
   }
 


### PR DESCRIPTION
(context: found while investigating https://github.com/nuxt-hub/core/issues/499 / followup of #488)


Currently `Process` polyfill extends `EventEmitter` but internal implementation of `EventEmitter` also uses process methods which makes a circular dependency.

This PR fixes issue by replacing simple usages in `EventEmitter`


