### PR TITLE
fix(node): tty default export for `ReadStream`

### DIFF
--- a/src/runtime/node/tty.ts
+++ b/src/runtime/node/tty.ts
@@ -10,7 +10,7 @@ export const isatty: typeof nodeTty.isatty = function () {
 };
 
 export default {
-  ReadStream: WriteStream as unknown as typeof nodeTty.ReadStream,
+  ReadStream: ReadStream as unknown as typeof nodeTty.ReadStream,
   WriteStream: WriteStream as unknown as typeof nodeTty.WriteStream,
   isatty,
 } satisfies typeof nodeTty;


### PR DESCRIPTION
Fixes: https://github.com/unjs/unenv/issues/512
