### PR TITLE
Fix call to Array.prototype.slice with context

### DIFF
--- a/src/runtime/node/internal/events/events.ts
+++ b/src/runtime/node/internal/events/events.ts
@@ -1311,7 +1311,7 @@ function arrayClone(arr: any[]) {
       return [arr[0], arr[1], arr[2], arr[3], arr[4], arr[5]];
   }
   // @ts-expect-error
-  return Array.prototype.slice(arr);
+  return Array.prototype.slice.call(arr);
 }
 
 function unwrapListeners(arr: Listener[]) {


### PR DESCRIPTION
This is returning an empty array when listeners are > 6

```html
<!DOCTYPE html>
<html>
<head>
  <title>esm.sh node:events bug - Minimal Reproduction</title>
</head>
<body>
  <h1>esm.sh node:events Bug - Minimal Reproduction</h1>
  <p>This demonstrates a bug in esm.sh's node:events polyfill when using more than 6 listeners.</p>
  
  <script type="module">
    // Import EventEmitter from esm.sh's node:events polyfill
    import { EventEmitter } from "https://esm.sh/node/events.mjs";
    
    const emitter = new EventEmitter();
    
    // Bug occurs when adding more than 6 listeners
    // Add 7 listeners to trigger the bug
    for (let i = 0; i < 7; i++) {
      emitter.on("test", () => {
        console.log(`Listener ${i + 1} called`);
      });
    }
    
    // This will throw: Cannot read properties of undefined (reading 'apply')
    emitter.emit("test");
  </script>
  
  <p>Expected: All 7 listeners should be called</p>
  <p>Actual: TypeError: Cannot read properties of undefined (reading 'apply')</p>
  <p>Open the browser console to see the error.</p>
</body>
</html>
```