### PR TITLE
fix(async_hooks): preserve store during async callbacks

### DIFF
--- a/src/runtime/node/internal/async_hooks/async-local-storage.ts
+++ b/src/runtime/node/internal/async_hooks/async-local-storage.ts
@@ -30,21 +30,42 @@ class _AsyncLocalStorage<T> implements nodeAsyncHooks.AsyncLocalStorage<T> {
     callback: (...args: TArgs) => R,
     ...args: TArgs
   ): R {
+    const previousStore = this._currentStore;
     this._currentStore = store;
-    const res = callback(...args);
-    this._currentStore = undefined;
-    return res;
+    try {
+      const res = callback(...args);
+      if (res != null && typeof (res as any).then === "function") {
+        return Promise.resolve(res).finally(() => {
+          this._currentStore = previousStore;
+        }) as R;
+      }
+      this._currentStore = previousStore;
+      return res;
+    } catch (error_) {
+      this._currentStore = previousStore;
+      throw error_;
+    }
   }
 
   exit<R, TArgs extends any[]>(
     callback: (...args: TArgs) => R,
     ...args: TArgs
   ): R {
-    const _previousStore = this._currentStore;
+    const previousStore = this._currentStore;
     this._currentStore = undefined;
-    const res = callback(...args);
-    this._currentStore = _previousStore;
-    return res;
+    try {
+      const res = callback(...args);
+      if (res != null && typeof (res as any).then === "function") {
+        return Promise.resolve(res).finally(() => {
+          this._currentStore = previousStore;
+        }) as R;
+      }
+      this._currentStore = previousStore;
+      return res;
+    } catch (error_) {
+      this._currentStore = previousStore;
+      throw error_;
+    }
   }
 
   static snapshot(): any {

--- a/test/async-hooks.test.ts
+++ b/test/async-hooks.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { AsyncLocalStorage } from "../src/runtime/node/async_hooks";
+
+describe("AsyncLocalStorage", () => {
+  describe("run", () => {
+    it("works with sync callback", () => {
+      const store = new AsyncLocalStorage<{ value: string }>();
+      const result = store.run(
+        { value: "sync" },
+        () => store.getStore()?.value,
+      );
+      expect(result).toBe("sync");
+    });
+
+    it("works with async callback", async () => {
+      const store = new AsyncLocalStorage<{ value: string }>();
+      const result = await store.run({ value: "async" }, async () => {
+        await Promise.resolve();
+        return store.getStore()?.value;
+      });
+      expect(result).toBe("async");
+    });
+
+    it("works with nested async", async () => {
+      const store = new AsyncLocalStorage<{ value: string }>();
+      const result = await store.run({ value: "outer" }, async () => {
+        const inner = await store.run({ value: "inner" }, async () => {
+          await Promise.resolve();
+          return store.getStore()?.value;
+        });
+        expect(inner).toBe("inner");
+        return store.getStore()?.value;
+      });
+      expect(result).toBe("outer");
+    });
+
+    it("restores store on sync throw", () => {
+      const store = new AsyncLocalStorage<{ value: string }>();
+      store.run({ value: "outer" }, () => {
+        expect(() =>
+          store.run({ value: "inner" }, () => {
+            throw new Error("sync error");
+          }),
+        ).toThrow("sync error");
+        expect(store.getStore()?.value).toBe("outer");
+      });
+    });
+
+    it("restores store on async reject", async () => {
+      const store = new AsyncLocalStorage<{ value: string }>();
+      await store.run({ value: "outer" }, async () => {
+        await expect(
+          store.run({ value: "inner" }, async () => {
+            await Promise.resolve();
+            throw new Error("async error");
+          }),
+        ).rejects.toThrow("async error");
+        expect(store.getStore()?.value).toBe("outer");
+      });
+    });
+
+    it("works with thenable without finally", async () => {
+      const store = new AsyncLocalStorage<{ value: string }>();
+      /* eslint-disable unicorn/no-thenable */
+      const thenable = {
+        then: (resolve: (v: string) => void) => resolve("thenable"),
+      };
+      /* eslint-enable unicorn/no-thenable */
+      const result = await store.run({ value: "test" }, () => thenable);
+      expect(result).toBe("thenable");
+    });
+  });
+
+  describe("exit", () => {
+    it("clears store in sync callback", () => {
+      const store = new AsyncLocalStorage<{ value: string }>();
+      store.run({ value: "outer" }, () => {
+        const result = store.exit(() => store.getStore());
+        expect(result).toBeUndefined();
+        expect(store.getStore()?.value).toBe("outer");
+      });
+    });
+
+    it("clears store in async callback", async () => {
+      const store = new AsyncLocalStorage<{ value: string }>();
+      await store.run({ value: "outer" }, async () => {
+        const result = await store.exit(async () => {
+          await Promise.resolve();
+          return store.getStore();
+        });
+        expect(result).toBeUndefined();
+        expect(store.getStore()?.value).toBe("outer");
+      });
+    });
+  });
+});


### PR DESCRIPTION
Related: https://github.com/better-auth/better-auth/issues/6613

## Problem

`AsyncLocalStorage.run()` clears the store synchronously, breaking async callbacks. When an async function awaits, the store becomes `undefined`.

## Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/unenv-als https://github.com/onmax/repros.git
cd repros && git sparse-checkout set unenv-als-broken-minimal
cd unenv-als-broken-minimal && pnpm i && pnpm test
```

**Expected**: `{ value: "test" }`
**Actual**: `undefined`

## Verify fix

```bash
git sparse-checkout add unenv-als-fixed
cd ../unenv-als-fixed && pnpm i && pnpm test
```

The `-fixed` folder includes a pnpm patch with the fix.


PS: there is a pre-existing issue with the node-coverage.test.ts snapshot failure exists on main (Node version difference) - unrelated to this PR.