### PR TITLE
feat(node): Filled in most util/types is* checks

### DIFF
--- a/src/runtime/node/internal/util/types.ts
+++ b/src/runtime/node/internal/util/types.ts
@@ -1,72 +1,92 @@
 import type nodeUtilTypes from "node:util/types";
 import { notImplemented } from "../../../_internal/utils.ts";
 
-export const isExternal: typeof nodeUtilTypes.isExternal = (_obj) => false;
+export const isExternal: typeof nodeUtilTypes.isExternal = (_obj: unknown) =>
+  false;
 
-export const isDate: typeof nodeUtilTypes.isDate = (val): val is Date =>
-  val instanceof Date;
+export const isDate: typeof nodeUtilTypes.isDate = (
+  val: unknown,
+): val is Date => val instanceof Date;
 
-export const isArgumentsObject = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isArgumentsObject
->("util.types.isArgumentsObject");
+export const isArgumentsObject: typeof nodeUtilTypes.isArgumentsObject = (
+  val: unknown,
+): val is IArguments =>
+  Object.prototype.toString.call(val) === "[object Arguments]";
 
-export const isBigIntObject = (val: any): val is bigint =>
-  typeof val === "bigint";
+export const isBigIntObject: typeof nodeUtilTypes.isBigIntObject = (
+  val: unknown,
+): val is BigInt => val instanceof BigInt;
 
 export const isBooleanObject: typeof nodeUtilTypes.isBooleanObject = (
-  val,
-): val is boolean => typeof val === "boolean";
+  val: unknown,
+): val is Boolean => val instanceof Boolean;
 
 export const isNumberObject: typeof nodeUtilTypes.isNumberObject = (
-  val,
-): val is number => typeof val === "number";
+  val: unknown,
+): val is Number => val instanceof Number;
 
 export const isStringObject: typeof nodeUtilTypes.isStringObject = (
-  val,
-): val is string => typeof val === "string";
+  val: unknown,
+): val is String => val instanceof String;
 
 export const isSymbolObject: typeof nodeUtilTypes.isSymbolObject = (
-  val,
-): val is symbol => typeof val === "symbol";
+  val: unknown,
+): val is Symbol => val instanceof Symbol;
 
-export const isNativeError = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isNativeError
->("util.types.isNativeError");
+export const isNativeError: typeof nodeUtilTypes.isNativeError = (
+  val: unknown,
+): val is Error => val instanceof Error;
 
-export const isRegExp: typeof nodeUtilTypes.isRegExp = (val): val is RegExp =>
-  val instanceof RegExp;
+export const isRegExp: typeof nodeUtilTypes.isRegExp = (
+  val: unknown,
+): val is RegExp => val instanceof RegExp;
 
-export const isAsyncFunction = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isAsyncFunction
->("util.types.isAsyncFunction");
+export const isAsyncFunction: typeof nodeUtilTypes.isAsyncFunction = (
+  val: unknown,
+): boolean => {
+  return typeof val === "function" &&
+    Object.prototype.toString.call(val) === "[object AsyncFunction]";
+};
 
-export const isGeneratorFunction = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isGeneratorFunction
->("util.types.isGeneratorFunction");
+export const isGeneratorFunction: typeof nodeUtilTypes.isGeneratorFunction = (
+  val: unknown,
+): val is GeneratorFunction => {
+  return typeof val === "function" &&
+    Object.prototype.toString.call(val) === "[object GeneratorFunction]";
+};
 
-export const isGeneratorObject = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isGeneratorObject
->("util.types.isGeneratorObject");
+export const isGeneratorObject: typeof nodeUtilTypes.isGeneratorObject = (
+  val: unknown,
+): val is Generator =>
+  Object.prototype.toString.call(val) === "[object Generator]";
 
 export const isPromise: typeof nodeUtilTypes.isPromise = (
-  val,
+  val: unknown,
 ): val is Promise<any> => val instanceof Promise;
 
-// @ts-ignore
-export const isMap: typeof nodeUtilTypes.isMap = (val): val is Map =>
-  val instanceof Map;
+export const isMap: typeof nodeUtilTypes.isMap = <T>(
+  val: unknown,
+): val is T extends ReadonlyMap<any, any>
+  ? (unknown extends T ? never : ReadonlyMap<any, any>)
+  : Map<unknown, unknown> => {
+  return val instanceof Map;
+};
 
-// @ts-ignore
-export const isSet: typeof nodeUtilTypes.isSet = (val): val is Set =>
-  val instanceof Set;
+export const isSet: typeof nodeUtilTypes.isSet = <T>(
+  val: unknown,
+): val is T extends ReadonlySet<any>
+  ? unknown extends T ? never : ReadonlySet<any>
+  : Set<unknown> => {
+  return val instanceof Set;
+};
 
-export const isMapIterator = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isMapIterator
->("util.types.isMapIterator");
+export const isMapIterator: typeof nodeUtilTypes.isMapIterator = (
+  val: unknown,
+): boolean => Object.prototype.toString.call(val) === "[object Map Iterator]";
 
-export const isSetIterator = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isSetIterator
->("util.types.isSetIterator");
+export const isSetIterator: typeof nodeUtilTypes.isSetIterator = (
+  val: unknown,
+): boolean => Object.prototype.toString.call(val) === "[object Set Iterator]";
 
 export const isWeakMap: typeof nodeUtilTypes.isWeakMap = <K extends WeakKey, V>(
   val: unknown,
@@ -77,85 +97,110 @@ export const isWeakSet: typeof nodeUtilTypes.isWeakSet = <K extends WeakKey>(
 ): val is WeakSet<K> => val instanceof WeakSet;
 
 export const isArrayBuffer: typeof nodeUtilTypes.isArrayBuffer = (
-  val,
+  val: unknown,
 ): val is ArrayBuffer => val instanceof ArrayBuffer;
 
 export const isDataView: typeof nodeUtilTypes.isDataView = (
-  val,
+  val: unknown,
 ): val is DataView => val instanceof DataView;
 
 export const isSharedArrayBuffer: typeof nodeUtilTypes.isSharedArrayBuffer = (
-  val,
-): val is SharedArrayBuffer => val instanceof SharedArrayBuffer;
+  val: unknown,
+): val is SharedArrayBuffer =>
+  "SharedArrayBuffer" in globalThis && val instanceof SharedArrayBuffer;
 
-export const isProxy =
-  /*@__PURE__*/ notImplemented<typeof nodeUtilTypes.isProxy>(
-    "util.types.isProxy",
-  );
+export const isProxy = /*@__PURE__*/ notImplemented<
+  typeof nodeUtilTypes.isProxy
+>(
+  "util.types.isProxy",
+);
 
 export const isModuleNamespaceObject = /*@__PURE__*/ notImplemented<
   typeof nodeUtilTypes.isModuleNamespaceObject
 >("util.types.isModuleNamespaceObject");
 
-export const isAnyArrayBuffer = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isAnyArrayBuffer
->("util.types.isAnyArrayBuffer");
+export const isAnyArrayBuffer: typeof nodeUtilTypes.isAnyArrayBuffer = (
+  val: unknown,
+): val is ArrayBuffer | SharedArrayBuffer =>
+  val instanceof ArrayBuffer ||
+  ("SharedArrayBuffer" in globalThis && val instanceof SharedArrayBuffer);
 
-export const isBoxedPrimitive = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isBoxedPrimitive
->("util.types.isBoxedPrimitive");
+export const isBoxedPrimitive: typeof nodeUtilTypes.isBoxedPrimitive = (
+  val: unknown,
+): val is String | Number | Boolean | BigInt | Symbol => {
+  return val instanceof String ||
+    val instanceof Number ||
+    val instanceof BigInt ||
+    val instanceof Boolean ||
+    val instanceof Symbol;
+};
 
-export const isArrayBufferView = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isArrayBufferView
->("util.types.isArrayBufferView");
+export const isArrayBufferView: typeof nodeUtilTypes.isArrayBufferView = (
+  val: unknown,
+): val is NodeJS.ArrayBufferView => {
+  return ArrayBuffer.isView(val);
+};
 
-export const isTypedArray = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isTypedArray
->("util.types.isTypedArray");
+export const isTypedArray: typeof nodeUtilTypes.isTypedArray = (
+  val: unknown,
+): val is NodeJS.TypedArray<ArrayBufferLike> => {
+  return val instanceof Int8Array ||
+    val instanceof Uint8Array ||
+    val instanceof Uint8ClampedArray ||
+    val instanceof Int16Array ||
+    val instanceof Uint16Array ||
+    val instanceof Int32Array ||
+    val instanceof Uint32Array ||
+    ("Float16Array" in globalThis && val instanceof Float16Array) ||
+    val instanceof Float32Array ||
+    val instanceof Float64Array ||
+    val instanceof BigInt64Array ||
+    val instanceof BigUint64Array;
+};
 
-export const isUint8Array = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isUint8Array
->("util.types.isUint8Array");
+export const isUint8Array: typeof nodeUtilTypes.isUint8Array = (
+  val: unknown,
+): val is Uint8Array => val instanceof Uint8Array;
 
-export const isUint8ClampedArray = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isUint8ClampedArray
->("util.types.isUint8ClampedArray");
+export const isUint8ClampedArray: typeof nodeUtilTypes.isUint8ClampedArray = (
+  val: unknown,
+): val is Uint8ClampedArray => val instanceof Uint8ClampedArray;
 
-export const isUint16Array = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isUint16Array
->("util.types.isUint16Array");
+export const isUint16Array: typeof nodeUtilTypes.isUint16Array = (
+  val: unknown,
+): val is Uint16Array => val instanceof Uint16Array;
 
-export const isUint32Array = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isUint32Array
->("util.types.isUint32Array");
+export const isUint32Array: typeof nodeUtilTypes.isUint32Array = (
+  val: unknown,
+): val is Uint32Array => val instanceof Uint32Array;
 
-export const isInt8Array = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isInt8Array
->("util.types.isInt8Array");
+export const isInt8Array: typeof nodeUtilTypes.isInt8Array = (
+  val: unknown,
+): val is Int8Array => val instanceof Int8Array;
 
-export const isInt16Array = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isInt16Array
->("util.types.isInt16Array");
+export const isInt16Array: typeof nodeUtilTypes.isInt16Array = (
+  val: unknown,
+): val is Int16Array => val instanceof Int16Array;
 
-export const isInt32Array = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isInt32Array
->("util.types.isInt32Array");
+export const isInt32Array: typeof nodeUtilTypes.isInt32Array = (
+  val: unknown,
+): val is Int32Array => val instanceof Int32Array;
 
-export const isFloat32Array = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isFloat32Array
->("util.types.isFloat32Array");
+export const isFloat32Array: typeof nodeUtilTypes.isFloat32Array = (
+  val: unknown,
+): val is Float32Array => val instanceof Float32Array;
 
-export const isFloat64Array = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isFloat64Array
->("util.types.isFloat64Array");
+export const isFloat64Array: typeof nodeUtilTypes.isFloat64Array = (
+  val: unknown,
+): val is Float64Array => val instanceof Float64Array;
 
-export const isBigInt64Array = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isBigInt64Array
->("util.types.isBigInt64Array");
+export const isBigInt64Array: typeof nodeUtilTypes.isBigInt64Array = (
+  val: unknown,
+): val is BigInt64Array => val instanceof BigInt64Array;
 
-export const isBigUint64Array = /*@__PURE__*/ notImplemented<
-  typeof nodeUtilTypes.isBigUint64Array
->("util.types.isBigUint64Array");
+export const isBigUint64Array: typeof nodeUtilTypes.isBigUint64Array = (
+  val: unknown,
+): val is BigUint64Array => val instanceof BigUint64Array;
 
 export const isKeyObject = /*@__PURE__*/ notImplemented<
   typeof nodeUtilTypes.isKeyObject


### PR DESCRIPTION
Not closing an issue as it's mostly just implementing a couple of functions that are `notImplemented`.

I also just did a general cleanup on the file and made the checks looks more alike.

While I was there I noticed a bug with the `is[Primitive]Object` implementations. They were checking with `typeof`, but `typeof new String` is actually `"object"` so I changed them to use `instanceof`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced many placeholder/no-op type checks with working implementations (promises, errors, functions, generators, iterators, boxed primitives, typed arrays, buffers, and more).

* **Refactor**
  * Standardized utilities to accept unknown inputs and return precise type predicates with explicit runtime checks for safer, consistent behavior.

* **New Features**
  * Added broader detection for Map/Set (generic-aware), array buffers, shared buffers, array-buffer views, typed-array variants, boxed primitives, and refined promise/type guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->