### PR TITLE
fix: use processModule as receiver when falling back in process polyfill (#541)

### DIFF
--- a/src/runtime/polyfill/process.ts
+++ b/src/runtime/polyfill/process.ts
@@ -9,7 +9,7 @@ globalThis.process = originalProcess
         if (Reflect.has(target, prop)) {
           return Reflect.get(target, prop, receiver);
         }
-        return Reflect.get(processModule, prop, receiver);
+        return Reflect.get(processModule, prop, processModule);
       },
     })
   : processModule;


### PR DESCRIPTION
### 🔗 Linked issue

Closes #541

### 📝 Description

The `process` polyfill uses a Proxy to layer unenv's polyfill over the original process object. When a property doesn't exist on the proxy target, it falls back to `processModule` (unenv's polyfill implementation):

```ts
return Reflect.get(processModule, prop, receiver);
```

The problem: `receiver` is the Proxy wrapping the **original** process, not `processModule`. When `processModule` has getters that rely on private fields (like `#stdout` in the `std` implementations), `Reflect.get` invokes the getter with `this = receiver` — which is the wrong object and lacks the private fields.

This causes:
```
Uncaught TypeError: Cannot read private member #t from an object whose class did not declare it.
```

### Fix

Pass `processModule` as the receiver instead of `receiver`:

```diff
- return Reflect.get(processModule, prop, receiver);
+ return Reflect.get(processModule, prop, processModule);
```

This ensures getters/methods on `processModule` are invoked with `this = processModule`, which has the expected private fields.

### Credit

Solution identified by the issue reporter @unjs/unenv#541.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the property access behavior in the process polyfill to ensure proper context binding when accessing properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->