### PR TITLE
docs(v1): fix `node` preset import in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Suitable to convert universal libraries working in Node.js.
 - Set Node.js built-ins as externals
 
 ```js
-import { env, nodeless } from "unenv";
+import { env, node } from "unenv";
 
 const envConfig = env(node, {});
 ```


### PR DESCRIPTION
Closes #509.

The example under the `### node` preset section in the v1 README imports `nodeless` but the line right below calls `env(node, {})`. The import is the typo — the section is documenting the `node` preset, so the import should be `{ env, node }`. The other preset sections (`nodeless`, `deno`, etc.) all import the matching name.

One-character README change, no source code touched, no behaviour change. Targeting `v1` since that's the branch the npm-published README comes from.

---

AI disclosure: I used Claude to locate the line in the v1 README and to draft this PR description. The fix itself is a single-word edit that matches the reporter's suggestion in #509.