### PR TITLE
fix(runtime/npm/debug): support full DEBUG namespace syntax + extend delimiter

### DIFF
--- a/src/runtime/npm/debug.ts
+++ b/src/runtime/npm/debug.ts
@@ -2,11 +2,65 @@
 
 import type { Debug, Debugger, Formatters } from "debug";
 
+// Cache the compiled patterns keyed on the DEBUG env value so we don't reparse
+// per log line. The cache is a single slot — DEBUG flips rarely at runtime and
+// strict equality on the env string is enough to invalidate when it does.
+let cachedEnv: string | undefined;
+let cachedPatterns: { names: RegExp[]; skips: RegExp[] } | undefined;
+
+function compileDebugEnv(
+  env: string | undefined,
+): { names: RegExp[]; skips: RegExp[] } | undefined {
+  if (env === cachedEnv) return cachedPatterns;
+  cachedEnv = env;
+  if (!env) {
+    cachedPatterns = undefined;
+    return undefined;
+  }
+
+  // The `debug` package splits DEBUG on `,` and whitespace, then treats a
+  // leading `-` as a negation. Each token is glob-style — `*` matches anything.
+  // Escape regex metacharacters first, then promote `*` to `.*` so wildcards
+  // like `worker:*` work, and anchor with `^…$` so e.g. `worker:abc` doesn't
+  // get matched by a pattern intended only for `worker`.
+  const names: RegExp[] = [];
+  const skips: RegExp[] = [];
+  for (const raw of env.split(/[\s,]+/)) {
+    if (!raw) continue;
+    const negated = raw.startsWith("-");
+    const pattern = negated ? raw.slice(1) : raw;
+    if (!pattern) continue;
+    const escaped = pattern
+      .replace(/[\\^$.+?()|[\]{}]/g, String.raw`\$&`)
+      .replace(/\*/g, ".*");
+    const re = new RegExp(`^${escaped}$`);
+    (negated ? skips : names).push(re);
+  }
+  cachedPatterns = { names, skips };
+  return cachedPatterns;
+}
+
+function isNamespaceEnabled(
+  namespace: string,
+  env: string | undefined,
+): boolean {
+  const patterns = compileDebugEnv(env);
+  if (!patterns) return false;
+  for (const skip of patterns.skips) {
+    if (skip.test(namespace)) return false;
+  }
+  for (const name of patterns.names) {
+    if (name.test(namespace)) return true;
+  }
+  return false;
+}
+
 function createDebug(namespace: string): Debugger {
   return Object.assign(
     (...args: any[]) => {
-      const env = globalThis.process?.env.DEBUG;
-      if (!env || (env !== "*" && !env.startsWith(namespace))) return;
+      if (!isNamespaceEnabled(namespace, globalThis.process?.env.DEBUG)) {
+        return;
+      }
       console.debug(...args);
     },
     {
@@ -16,7 +70,12 @@ function createDebug(namespace: string): Debugger {
       log: console.debug.bind(console),
       namespace,
       destroy: () => false,
-      extend: (ns: string, _del?: string) => createDebug(namespace + ns),
+      // The upstream `debug` package joins extended namespaces with a
+      // delimiter (`:` by default), so `createDebug("app").extend("worker")`
+      // yields `app:worker`, not `appworker`. Honour the caller-supplied
+      // delimiter when provided.
+      extend: (ns: string, delimiter: string = ":") =>
+        createDebug(`${namespace}${delimiter}${ns}`),
     },
   );
 }

--- a/test/runtime-npm-debug.test.ts
+++ b/test/runtime-npm-debug.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import createDebug from "../src/runtime/npm/debug";
+
+// Tests for the `debug` package polyfill's namespace matching. Regression
+// coverage for #546 — the previous implementation only enabled a debugger
+// when DEBUG was `*` or startsWith() the namespace, so comma-separated lists
+// (`worker1,worker2`) and wildcard patterns (`worker:*`) were silently
+// dropped. The polyfill now mirrors the upstream `debug` package's
+// glob-with-negation parsing.
+
+describe("runtime/npm/debug namespace matching", () => {
+  let consoleDebug: ReturnType<typeof vi.spyOn>;
+  let originalDebugEnv: string | undefined;
+
+  beforeEach(() => {
+    originalDebugEnv = process.env.DEBUG;
+    consoleDebug = vi.spyOn(console, "debug").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalDebugEnv === undefined) {
+      delete process.env.DEBUG;
+    } else {
+      process.env.DEBUG = originalDebugEnv;
+    }
+    consoleDebug.mockRestore();
+  });
+
+  it("emits when DEBUG is '*'", () => {
+    process.env.DEBUG = "*";
+    createDebug("worker:db")("hello");
+    expect(consoleDebug).toHaveBeenCalledWith("hello");
+  });
+
+  it("emits when DEBUG matches the namespace exactly", () => {
+    process.env.DEBUG = "worker";
+    createDebug("worker")("hello");
+    expect(consoleDebug).toHaveBeenCalledWith("hello");
+  });
+
+  it("does not emit when DEBUG is unset", () => {
+    delete process.env.DEBUG;
+    createDebug("worker")("hello");
+    expect(consoleDebug).not.toHaveBeenCalled();
+  });
+
+  it("supports comma-separated namespaces", () => {
+    process.env.DEBUG = "worker1,worker2";
+    createDebug("worker1")("a");
+    createDebug("worker2")("b");
+    createDebug("worker3")("c");
+    expect(consoleDebug).toHaveBeenCalledTimes(2);
+    expect(consoleDebug).toHaveBeenNthCalledWith(1, "a");
+    expect(consoleDebug).toHaveBeenNthCalledWith(2, "b");
+  });
+
+  it("supports whitespace-separated namespaces", () => {
+    process.env.DEBUG = "alpha  beta";
+    createDebug("alpha")("a");
+    createDebug("beta")("b");
+    createDebug("gamma")("c");
+    expect(consoleDebug).toHaveBeenCalledTimes(2);
+  });
+
+  it("supports namespace wildcards via *", () => {
+    process.env.DEBUG = "worker:*";
+    createDebug("worker:db")("a");
+    createDebug("worker:queue")("b");
+    createDebug("other")("c");
+    expect(consoleDebug).toHaveBeenCalledTimes(2);
+    expect(consoleDebug).toHaveBeenNthCalledWith(1, "a");
+    expect(consoleDebug).toHaveBeenNthCalledWith(2, "b");
+  });
+
+  it("does not emit when the wildcard pattern excludes the namespace", () => {
+    // `worker:*` must NOT match the bare `worker` namespace (anchor check).
+    process.env.DEBUG = "worker:*";
+    createDebug("worker")("hello");
+    expect(consoleDebug).not.toHaveBeenCalled();
+  });
+
+  it("supports negation with leading '-'", () => {
+    process.env.DEBUG = "worker:*,-worker:internal";
+    createDebug("worker:db")("a");
+    createDebug("worker:internal")("b");
+    expect(consoleDebug).toHaveBeenCalledTimes(1);
+    expect(consoleDebug).toHaveBeenCalledWith("a");
+  });
+
+  it("anchors patterns so a prefix doesn't accidentally match longer namespaces", () => {
+    // The original impl used String#startsWith which would have falsely
+    // matched `worker` when DEBUG was `work`. With proper anchoring the
+    // shorter pattern can only match the shorter namespace.
+    process.env.DEBUG = "work";
+    createDebug("worker")("hello");
+    expect(consoleDebug).not.toHaveBeenCalled();
+  });
+
+  it("re-reads DEBUG when it changes between calls", () => {
+    process.env.DEBUG = "worker";
+    const log = createDebug("worker");
+    log("first");
+    expect(consoleDebug).toHaveBeenCalledTimes(1);
+
+    process.env.DEBUG = "other";
+    log("second");
+    expect(consoleDebug).toHaveBeenCalledTimes(1); // unchanged
+  });
+});
+
+describe("runtime/npm/debug .extend", () => {
+  it("joins with ':' by default to match the upstream debug package", () => {
+    const child = createDebug("app").extend("worker");
+    expect(child.namespace).toBe("app:worker");
+  });
+
+  it("honours a caller-supplied delimiter", () => {
+    const child = createDebug("app").extend("worker", "/");
+    expect(child.namespace).toBe("app/worker");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #546.

The `debug` polyfill at `src/runtime/npm/debug.ts` enabled a debugger only when DEBUG was exactly `*` or `env.startsWith(namespace)`. That silently dropped two well-documented features of the upstream [`debug`](https://www.npmjs.com/package/debug) package:

- **Comma- or whitespace-separated namespace lists** — `DEBUG=worker1,worker2` enabled NEITHER `worker1` nor `worker2` (only the literal string `worker1,worker2` as a prefix).
- **Wildcard patterns** — `DEBUG=worker:*` did not match `worker:db` / `worker:queue` because the env didn't `startsWith` the child namespace.

And because `startsWith` is unanchored, `DEBUG=work` would also have falsely enabled the `worker` namespace (no boundary).

## Fix

Implement the upstream parsing algorithm. Split DEBUG on `,` / whitespace, treat a leading `-` as a negation, glob-escape regex metacharacters, promote `*` to `.*`, anchor with `^…$`. A namespace is enabled when it matches at least one include pattern and no exclude pattern.

```ts
for (const raw of env.split(/[\s,]+/)) {
  if (!raw) continue;
  const negated = raw.startsWith("-");
  const pattern = negated ? raw.slice(1) : raw;
  const escaped = pattern
    .replace(/[\\^$.+?()|[\]{}]/g, String.raw\`\\\$&\`)
    .replace(/\*/g, ".*");
  const re = new RegExp(\`^\${escaped}\$\`);
  (negated ? skips : names).push(re);
}
```

Compiled patterns are cached in a single slot keyed on the env string so the common case (DEBUG unchanged between log calls) does not reparse. Cache invalidation is `===` on the string — DEBUG flips rarely at runtime and that's sufficient.

Also fixed `extend(ns, delimiter)` which previously discarded the delimiter argument and concatenated raw:

```diff
-extend: (ns: string, _del?: string) => createDebug(namespace + ns),
+extend: (ns: string, delimiter: string = ":") =>
+  createDebug(\`\${namespace}\${delimiter}\${ns}\`),
```

So `createDebug("app").extend("worker")` now yields `app:worker` (matching upstream) instead of `appworker`. The delimiter parameter is honoured when supplied.

## Tests

New file `test/runtime-npm-debug.test.ts`. 12 tests covering:

- `*`, exact match, env unset (baseline)
- comma-separated namespaces
- whitespace-separated namespaces
- wildcard pattern (`worker:*`)
- anchor guard (`worker:*` does NOT match the bare `worker`)
- negation (`-worker:internal`)
- prefix-not-substring (`DEBUG=work` does NOT enable `worker`)
- env-change-detection between calls
- `extend` default delimiter (`:`)
- `extend` custom delimiter

Verified the new tests fail on `main` (7/12 fail) and pass on this branch (12/12).

## Test plan

- [x] `npx vitest run test/runtime-npm-debug.test.ts` — 12/12 pass
- [x] Verified failure-on-master by stashing the production change and re-running — 7/12 fail, confirming the tests are real regressions and not just covering already-correct behavior
- [x] `npm run lint` clean for the touched files (the 5 prettier warnings surfaced are pre-existing in files this PR does not touch)

## Out of scope

The full upstream `debug` API also handles `humanize`, color picking, and the `enable()`/`disable()` runtime control. This PR keeps the existing pass-through stubs for those — they're separately tracked and out of scope for the namespace-matching regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced DEBUG environment variable parsing with improved pattern matching for namespace filtering, including support for wildcards, exclusion patterns, and proper delimiter handling.

* **Tests**
  * Added comprehensive test coverage for debug namespace matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->