### PR TITLE
fix: strip trailing slash from resolved node builtins

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -120,10 +120,15 @@ function resolvePaths(
       id = resolveAlias(id, env.alias);
     }
     if (id.startsWith("node:")) {
+      const builtinId = id.slice(5).replace(/\/$/, "");
+      if (builtinModules.includes(builtinId)) {
+        return `node:${builtinId}`;
+      }
       return id;
     }
-    if (builtinModules.includes(id)) {
-      return `node:${id}`;
+    const builtinId = id.replace(/\/$/, "");
+    if (builtinModules.includes(builtinId)) {
+      return `node:${builtinId}`;
     }
     let resolved = resolveModulePath(id, { try: true });
     if (!resolved && id.startsWith("unenv/")) {

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -54,6 +54,21 @@ describe("defineEnv", () => {
   });
 
   describe("resolvePath", () => {
+    it("strips trailing slash when resolving builtin aliases", () => {
+      const { env } = defineEnv({
+        nodeCompat: false,
+        resolve: true,
+        overrides: {
+          alias: {
+            punycode: "node:punycode",
+            foo: "punycode/",
+          },
+        },
+      });
+
+      expect(env.alias.foo).toBe("node:punycode");
+    });
+
     it("resolves all nodeCompat paths", () => {
       const { env } = defineEnv({ nodeCompat: true, resolve: true });
       for (const [from, to] of Object.entries(env.alias)) {


### PR DESCRIPTION
resolves #555

This PR
- Strips the trailing slash
- Includes a test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module path resolution to properly normalize trailing slashes in module identifiers, ensuring consistent canonicalization across different reference formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->