### PR TITLE
fix(env): strip trailing slash from node: builtin specifiers (#555)

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -120,6 +120,16 @@ function resolvePaths(
       id = resolveAlias(id, env.alias);
     }
     if (id.startsWith("node:")) {
+      // `node:` builtin specifiers must not carry a trailing slash; Node throws
+      // ERR_UNKNOWN_BUILTIN_MODULE for `node:punycode/` even though the package
+      // form `punycode/` is legal. Strip the slash only when the rest is a
+      // real builtin, so unrelated `node:`-prefixed strings are untouched.
+      if (id.endsWith("/")) {
+        const trimmed = id.slice(0, -1);
+        if (builtinModules.includes(trimmed.slice("node:".length))) {
+          return trimmed;
+        }
+      }
       return id;
     }
     if (builtinModules.includes(id)) {

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -67,5 +67,42 @@ describe("defineEnv", () => {
         expect(existsSync(to), inject.toString()).toBe(true);
       }
     });
+
+    it("strips trailing slash when an alias chains to a node: builtin", () => {
+      const { env } = defineEnv({
+        nodeCompat: false,
+        resolve: true,
+        overrides: {
+          alias: {
+            punycode: "node:punycode",
+            foo: "punycode/",
+          },
+        },
+      });
+      // `node:punycode/` would throw ERR_UNKNOWN_BUILTIN_MODULE at runtime.
+      expect(env.alias.foo).toBe("node:punycode");
+    });
+
+    it("leaves a literal node: specifier without a trailing slash unchanged", () => {
+      const { env } = defineEnv({
+        nodeCompat: false,
+        resolve: true,
+        overrides: {
+          alias: { foo: "node:punycode" },
+        },
+      });
+      expect(env.alias.foo).toBe("node:punycode");
+    });
+
+    it("does not strip a trailing slash from non-builtin node:-prefixed values", () => {
+      const { env } = defineEnv({
+        nodeCompat: false,
+        resolve: true,
+        overrides: {
+          alias: { foo: "node:not-a-real-builtin/" },
+        },
+      });
+      expect(env.alias.foo).toBe("node:not-a-real-builtin/");
+    });
   });
 });


### PR DESCRIPTION
Closes #555.

When an alias chain feeds `_resolve` a value like `punycode/`, `pathe`'s `resolveAlias` rewrites it through the `punycode -> node:punycode` mapping and tacks the trailing slash back on, producing `node:punycode/`. That string then hits the `id.startsWith("node:")` short-circuit and was returned verbatim. Node rejects the resulting specifier with `ERR_UNKNOWN_BUILTIN_MODULE` because trailing slashes are not legal on `node:` builtins, even though the equivalent package form `punycode/` is fine.

The fix normalises only inside the `node:` branch and only when the trimmed name is a real builtin. So:

- `node:punycode/` -> `node:punycode` (the bug)
- `node:punycode` -> unchanged
- `node:not-a-real-builtin/` -> unchanged (no surprise rewrites of unknown values)
- non-`node:` strings -> unchanged path

This keeps the regular package-path behaviour the issue calls out (`my-module/` stays `my-module/`).

## Tests

Three new cases under `describe("resolvePath")` in `test/env.test.ts`:

- the reporter's repro: an alias chain that ends at `punycode/` resolves to `node:punycode`
- a literal `node:punycode` alias stays unchanged
- a `node:not-a-real-builtin/` alias is left alone

All three pass with the patch and fail (or never run) against `main`. The pre-existing `resolves all nodeCompat paths` failure on `main` (`unenv/node/inspector/promises` missing) is unrelated; confirmed by running the suite on `main` without these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed resolution of Node builtin module aliases with trailing slashes to prevent loading invalid or unknown builtin identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->