### PR TITLE
fix(runtime/npm/debug): support namespace patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .vscode
 node_modules
 *.log*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.DS_Store
 .vscode
 node_modules
 *.log*

--- a/src/runtime/npm/debug.ts
+++ b/src/runtime/npm/debug.ts
@@ -2,11 +2,49 @@
 
 import type { Debug, Debugger, Formatters } from "debug";
 
+const enabledPatterns: RegExp[] = [];
+const skippedPatterns: RegExp[] = [];
+// DEBUG is read for every log call, so only recompile when its value changes.
+let cachedDebugEnv: string | undefined;
+
+function compileNamespacePattern(pattern: string): RegExp {
+  const source = pattern
+    .split("*")
+    .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`))
+    .join(".*");
+  return new RegExp(`^${source}$`);
+}
+
+function isNamespaceEnabled(namespace: string): boolean {
+  const env = globalThis.process?.env.DEBUG;
+
+  if (env !== cachedDebugEnv) {
+    cachedDebugEnv = env;
+    enabledPatterns.length = 0;
+    skippedPatterns.length = 0;
+
+    for (const entry of env?.split(/[\s,]+/) ?? []) {
+      if (!entry) continue;
+      const isSkip = entry.startsWith("-");
+      const pattern = isSkip ? entry.slice(1) : entry;
+      if (!pattern) continue;
+      (isSkip ? skippedPatterns : enabledPatterns).push(
+        compileNamespacePattern(pattern),
+      );
+    }
+  }
+
+  if (!env) return false;
+  return (
+    !skippedPatterns.some((pattern) => pattern.test(namespace)) &&
+    enabledPatterns.some((pattern) => pattern.test(namespace))
+  );
+}
+
 function createDebug(namespace: string): Debugger {
   return Object.assign(
     (...args: any[]) => {
-      const env = globalThis.process?.env.DEBUG;
-      if (!env || (env !== "*" && !env.startsWith(namespace))) return;
+      if (!isNamespaceEnabled(namespace)) return;
       console.debug(...args);
     },
     {

--- a/test/runtime-npm-debug.test.ts
+++ b/test/runtime-npm-debug.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import createDebug from "../src/runtime/npm/debug";
+
+describe("runtime/npm/debug namespace matching", () => {
+  const originalDebugEnv = process.env.DEBUG;
+
+  beforeEach(() => {
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalDebugEnv === undefined) {
+      delete process.env.DEBUG;
+    } else {
+      process.env.DEBUG = originalDebugEnv;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("supports comma- and whitespace-separated namespaces", () => {
+    process.env.DEBUG = "worker1, worker2";
+
+    createDebug("worker1")("one");
+    createDebug("worker2")("two");
+    createDebug("worker3")("three");
+
+    expect(console.debug).toHaveBeenCalledTimes(2);
+    expect(console.debug).toHaveBeenNthCalledWith(1, "one");
+    expect(console.debug).toHaveBeenNthCalledWith(2, "two");
+  });
+
+  it("supports wildcards and namespace exclusions", () => {
+    process.env.DEBUG = "worker:*,-worker:internal";
+
+    createDebug("worker:queue")("queue");
+    createDebug("worker:internal")("internal");
+    createDebug("worker")("parent");
+
+    expect(console.debug).toHaveBeenCalledOnce();
+    expect(console.debug).toHaveBeenCalledWith("queue");
+  });
+
+  it("matches complete namespaces instead of prefixes", () => {
+    process.env.DEBUG = "worker";
+
+    createDebug("worker")("exact");
+    createDebug("work")("prefix");
+
+    expect(console.debug).toHaveBeenCalledOnce();
+    expect(console.debug).toHaveBeenCalledWith("exact");
+  });
+
+  it("treats regular expression characters as literals", () => {
+    process.env.DEBUG = "worker.v1";
+
+    createDebug("worker.v1")("exact");
+    createDebug("workerXv1")("pattern");
+
+    expect(console.debug).toHaveBeenCalledOnce();
+    expect(console.debug).toHaveBeenCalledWith("exact");
+  });
+
+  it("re-evaluates a debugger when DEBUG changes", () => {
+    const log = createDebug("worker");
+    process.env.DEBUG = "worker";
+    log("enabled");
+
+    process.env.DEBUG = "other";
+    log("disabled");
+
+    expect(console.debug).toHaveBeenCalledOnce();
+    expect(console.debug).toHaveBeenCalledWith("enabled");
+  });
+});


### PR DESCRIPTION
## Summary

- parse `DEBUG` as comma- or whitespace-separated namespace patterns
- support wildcard matches and `-` exclusions while treating regex characters literally
- cache compiled patterns until `DEBUG` changes
- add focused regression coverage

Closes #546.

## Context

This follows the investigation in #554, which its author closed unmerged after it became stale. This version is based on current `main` and keeps the change focused on the namespace-matching behavior requested in #546; it does not include the unrelated `extend()` change from that PR.

## Validation

Run with the repository-required Node 22.14.0 and pnpm 10.23.0:

- `pnpm vitest --run test/runtime-npm-debug.test.ts` — 5 passed
- `pnpm lint`
- `pnpm test:types`
- `pnpm build`
- `pnpm vitest --run` — 26 passed

AI assistance disclosure: Codex was used to investigate, implement, and test this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug logging controls with support for wildcard patterns, exclusions, and comma- or whitespace-separated namespaces.
  * Debug output now reflects changes to the `DEBUG` setting immediately and avoids unintended matches.

* **Tests**
  * Added coverage for namespace matching, exclusions, special characters, and runtime configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
